### PR TITLE
Fix parsing bug when STRLEN is used.

### DIFF
--- a/lib/sparql.jison
+++ b/lib/sparql.jison
@@ -339,7 +339,7 @@ PN_LOCAL_ESC          "\\"("_"|"~"|"."|"-"|"!"|"$"|"&"|"'"|"("|")"|"*"|"+"|","|"
 "BOUND"                  return 'BOUND'
 "BNODE"                  return 'BNODE'
 ("RAND"|"NOW"|"UUID"|"STUUID") return 'FUNC_ARITY0'
-("STR"|"LANG"|"DATATYPE"|"IRI"|"URI"|"ABS"|"CEIL"|"FLOOR"|"ROUND"|"STRLEN"|"UCASE"|"LCASE"|"ENCODE_FOR_URI"|"YEAR"|"MONTH"|"DAY"|"HOURS"|"MINUTES"|"SECONDS"|"TIMEZONE"|"TZ"|"MD5"|"SHA1"|"SHA256"|"SHA384"|"SHA512"|"isIRI"|"isURI"|"isBLANK"|"isLITERAL"|"isNUMERIC") return 'FUNC_ARITY1'
+("LANG"|"DATATYPE"|"IRI"|"URI"|"ABS"|"CEIL"|"FLOOR"|"ROUND"|"STRLEN"|"STR"|"UCASE"|"LCASE"|"ENCODE_FOR_URI"|"YEAR"|"MONTH"|"DAY"|"HOURS"|"MINUTES"|"SECONDS"|"TIMEZONE"|"TZ"|"MD5"|"SHA1"|"SHA256"|"SHA384"|"SHA512"|"isIRI"|"isURI"|"isBLANK"|"isLITERAL"|"isNUMERIC") return 'FUNC_ARITY1'
 ("LANGMATCHES"|"CONTAINS"|"STRSTARTS"|"STRENDS"|"STRBEFORE"|"STRAFTER"|"STRLANG"|"STRDT"|"sameTerm") return 'FUNC_ARITY2'
 "CONCAT"                 return 'CONCAT'
 "COALESCE"               return 'COALESCE'

--- a/queries/strlen.sparql
+++ b/queries/strlen.sparql
@@ -1,0 +1,1 @@
+SELECT ?str (STRLEN(?str) as ?strlen) { [] ?p ?str }

--- a/test/parsedQueries/strlen.json
+++ b/test/parsedQueries/strlen.json
@@ -1,0 +1,30 @@
+{
+  "type": "query",
+  "queryType": "SELECT",
+  "variables": [
+    "?str",
+    {
+      "expression": {
+        "type": "operation",
+        "operator": "strlen",
+        "args": [
+          "?str"
+        ]
+      },
+      "variable": "?strlen"
+    }
+  ],
+  "where": [
+    {
+      "type": "bgp",
+      "triples": [
+        {
+          "subject": "_:b0",
+          "predicate": "?p",
+          "object": "?str"
+        }
+      ]
+    }
+  ],
+  "prefixes": {}
+}


### PR DESCRIPTION
It seems like the order of the rules for unary functions is important (or any
rules in a list of options for that matter), when
using `STRLEN` in a query, the parser is matching `STR` first.
Rearranging the rules seems to fix it.