### PR TITLE
Fix order for generated SolutionModifiers.

### DIFF
--- a/lib/SparqlGenerator.js
+++ b/lib/SparqlGenerator.js
@@ -34,18 +34,18 @@ function toQuery(q) {
   else if (q.values)
     query += patterns.values(q);
 
-  if (q.order)
-    query += 'ORDER BY ' + mapJoin(q.order, function (it) {
-      var expr = toExpression(it.expression);
-      return !it.descending ? expr : 'DESC(' + expr + ')';
-    }) + '\n';
   if (q.group)
     query += 'GROUP BY ' + mapJoin(q.group, function (it) {
       return isString(it.expression) ? it.expression : '(' + toExpression(it.expression) + ')';
     }) + '\n';
   if (q.having)
     query += 'HAVING (' + mapJoin(q.having, toExpression) + ')\n';
-
+  if (q.order)
+    query += 'ORDER BY ' + mapJoin(q.order, function (it) {
+      var expr = toExpression(it.expression);
+      return !it.descending ? expr : 'DESC(' + expr + ')';
+    }) + '\n';
+  
   if (q.offset)
     query += 'OFFSET ' + q.offset + '\n';
   if (q.limit)

--- a/queries/sparql-modifiers-order.sparql
+++ b/queries/sparql-modifiers-order.sparql
@@ -1,0 +1,10 @@
+PREFIX : <http://books.example/>
+SELECT (SUM(?lprice) AS ?totalPrice)
+WHERE {
+  ?org :affiliates ?auth .
+  ?auth :writesBook ?book .
+  ?book :price ?lprice .
+}
+GROUP BY ?org
+HAVING (SUM(?lprice) > 10)
+ORDER BY ?totalPrice

--- a/test/parsedQueries/sparql-modifiers-order.json
+++ b/test/parsedQueries/sparql-modifiers-order.json
@@ -1,0 +1,65 @@
+{
+  "type": "query",
+  "prefixes": {
+    "": "http://books.example/"
+  },
+  "queryType": "SELECT",
+  "variables": [
+    {
+      "expression": {
+        "expression": "?lprice",
+        "type": "aggregate",
+        "aggregation": "sum",
+        "distinct": false
+      },
+      "variable": "?totalPrice"
+    }
+  ],
+  "where": [
+    {
+      "type": "bgp",
+      "triples": [
+        {
+          "subject": "?org",
+          "predicate": "http://books.example/affiliates",
+          "object": "?auth"
+        },
+        {
+          "subject": "?auth",
+          "predicate": "http://books.example/writesBook",
+          "object": "?book"
+        },
+        {
+          "subject": "?book",
+          "predicate": "http://books.example/price",
+          "object": "?lprice"
+        }
+      ]
+    }
+  ],
+  "group": [
+    {
+      "expression": "?org"
+    }
+  ],
+  "having": [
+    {
+      "type": "operation",
+      "operator": ">",
+      "args": [
+        {
+          "expression": "?lprice",
+          "type": "aggregate",
+          "aggregation": "sum",
+          "distinct": false
+        },
+        "\"10\"^^http://www.w3.org/2001/XMLSchema#integer"
+      ]
+    }
+  ],
+  "order": [
+    {
+      "expression": "?totalPrice"
+    }
+  ]
+}


### PR DESCRIPTION
According to Sparql EBNF SolutionModifiers have predefined order:
[18]  	SolutionModifier	  ::=  	GroupClause? HavingClause? OrderClause? LimitOffsetClauses?

E.g ORDER BY clause can't be before GROUP BY clause. This change makes
SparqlGenerator consistent with this grammar rule.