### PR TITLE
add a space before dot so the generated sparql can be used with Virtuoso

### DIFF
--- a/lib/SparqlGenerator.js
+++ b/lib/SparqlGenerator.js
@@ -63,7 +63,7 @@ function toPattern(pattern) {
 }
 var patterns = {
   triple: function (t) {
-    return toEntity(t.subject) + ' ' + toEntity(t.predicate) + ' ' + toEntity(t.object) + '.';
+    return toEntity(t.subject) + ' ' + toEntity(t.predicate) + ' ' + toEntity(t.object) + ' .';
   },
   array: function (items) {
     return mapJoin(items, toPattern, '\n');


### PR DESCRIPTION
The generated sparql make Virtuoso crash with the following message

```
Virtuoso 37000 Error SP030: SPARQL compiler, line 11: syntax error at '<http://test.org/instances/bp1>' before '<http://www.w3.org/1999/02/22-rdf-syntax-ns#type>'

SPARQL query:
define sql:big-data-const 0 DELETE { GRAPH <http://test.org> { ?s ?p ?o. } }
WHERE {
  ?s ?p ?o.
  FILTER(?s IN(<http://test.org/instances/bp0>, <http://test.org/instances/bp1>, <http://test.org/instances/bp2>, <http://test.org/instances/bp3>, <http://test.org/instances/bp4>, <http://test.org/instances/bp5>, <http://test.org/instances/bp6>, <http://test.org/instances/bp7>, <http://test.org/instances/bp8>, <http://test.org/instances/bp9>))
};
INSERT DATA {
  GRAPH <http://test.org> {
    <http://test.org/instances/bp0> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://test.org/classes/BlogPost>.
    <http://test.org/instances/bp0> <http://test.org/properties/title> "post 0".
    <http://test.org/instances/bp0> <http://test.org/properties/ratting> 0.
    <http://test.org/instances/bp1> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://test.org/classes/BlogPost>.
    <http://test.org/instances/bp1> <http://test.org/properties/title> "post 1".
    <http://test.org/instances/bp1> <http://test.org/properties/ratting> 1.
    <http://test.org/instances/bp2> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://test.org/classes/BlogPost>.
    <http://test.org/instances/bp2> <http://test.org/properties/title> "post 2".
    <http://test.org/instances/bp2> <http://test.org/properties/ratting> 2.
    <http://test.org/instances/bp3> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://test.org/classes/BlogPost>.
    <http://test.org/instances/bp3> <http://test.org/properties/title> "post 3".
    <http://test.org/instances/bp3> <http://test.org/properties/ratting> 3.
    <http://test.org/instances/bp4> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://test.org/classes/BlogPost>.
    <http://test.org/instances/bp4> <http://test.org/properties/title> "post 4".
    <http://test.org/instances/bp4> <http://test.org/properties/ratting> 4.
    <http://test.org/instances/bp5> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://test.org/classes/BlogPost>.
    <http://test.org/instances/bp5> <http://test.org/properties/title> "post 5".
    <http://test.org/instances/bp5> <http://test.org/properties/ratting> 0.
    <http://test.org/instances/bp6> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://test.org/classes/BlogPost>.
    <http://test.org/instances/bp6> <http://test.org/properties/title> "post 6".
    <http://test.org/instances/bp6> <http://test.org/properties/ratting> 1.
    <http://test.org/instances/bp7> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://test.org/classes/BlogPost>.
    <http://test.org/instances/bp7> <http://test.org/properties/title> "post 7".
    <http://test.org/instances/bp7> <http://test.org/properties/ratting> 2.
    <http://test.org/instances/bp8> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://test.org/classes/BlogPost>.
    <http://test.org/instances/bp8> <http://test.org/properties/title> "post 8".
    <http://test.org/instances/bp8> <http://test.org/properties/ratting> 3.
    <http://test.org/instances/bp9> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://test.org/classes/BlogPost>.
    <http://test.org/instances/bp9> <http://test.org/properties/title> "post 9".
    <http://test.org/instances/bp9> <http://test.org/properties/ratting> 4.
  }
}
```

This is due of the absence of space before the dot at the end of the triple. The following query works well:

```
DELETE { GRAPH <http://test.org> { ?s ?p ?o . } }
WHERE {
  ?s ?p ?o .
  FILTER(?s IN(<http://test.org/instances/bp0>, <http://test.org/instances/bp1>, <http://test.org/instances/bp2>, <http://test.org/instances/bp3>, <http://test.org/instances/bp4>, <http://test.org/instances/bp5>, <http://test.org/instances/bp6>, <http://test.org/instances/bp7>, <http://test.org/instances/bp8>, <http://test.org/instances/bp9>))
};
INSERT DATA {
  GRAPH <http://test.org> {
    <http://test.org/instances/bp0> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://test.org/classes/BlogPost> .
    <http://test.org/instances/bp0> <http://test.org/properties/title> "post 0" .
    <http://test.org/instances/bp0> <http://test.org/properties/ratting> 0 .
    <http://test.org/instances/bp1> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://test.org/classes/BlogPost> .
    <http://test.org/instances/bp1> <http://test.org/properties/title> "post 1" .
    <http://test.org/instances/bp1> <http://test.org/properties/ratting> 1 .
    <http://test.org/instances/bp2> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://test.org/classes/BlogPost> .
    <http://test.org/instances/bp2> <http://test.org/properties/title> "post 2" .
    <http://test.org/instances/bp2> <http://test.org/properties/ratting> 2 .
    <http://test.org/instances/bp3> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://test.org/classes/BlogPost> .
    <http://test.org/instances/bp3> <http://test.org/properties/title> "post 3" .
    <http://test.org/instances/bp3> <http://test.org/properties/ratting> 3 .
    <http://test.org/instances/bp4> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://test.org/classes/BlogPost> .
    <http://test.org/instances/bp4> <http://test.org/properties/title> "post 4" .
    <http://test.org/instances/bp4> <http://test.org/properties/ratting> 4 .
    <http://test.org/instances/bp5> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://test.org/classes/BlogPost> .
    <http://test.org/instances/bp5> <http://test.org/properties/title> "post 5" .
    <http://test.org/instances/bp5> <http://test.org/properties/ratting> 0 .
    <http://test.org/instances/bp6> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://test.org/classes/BlogPost> .
    <http://test.org/instances/bp6> <http://test.org/properties/title> "post 6" .
    <http://test.org/instances/bp6> <http://test.org/properties/ratting> 1 .
    <http://test.org/instances/bp7> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://test.org/classes/BlogPost> .
    <http://test.org/instances/bp7> <http://test.org/properties/title> "post 7" .
    <http://test.org/instances/bp7> <http://test.org/properties/ratting> 2 .
    <http://test.org/instances/bp8> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://test.org/classes/BlogPost> .
    <http://test.org/instances/bp8> <http://test.org/properties/title> "post 8" .
    <http://test.org/instances/bp8> <http://test.org/properties/ratting> 3 .
    <http://test.org/instances/bp9> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://test.org/classes/BlogPost> .
    <http://test.org/instances/bp9> <http://test.org/properties/title> "post 9" .
    <http://test.org/instances/bp9> <http://test.org/properties/ratting> 4 .
  }
}
```

