### PR TITLE
Modify Generator to bypass entity IRI wrapping

### DIFF
--- a/lib/SparqlGenerator.js
+++ b/lib/SparqlGenerator.js
@@ -182,6 +182,9 @@ function toEntity(value) {
     case '*':
     case '_':
       return value;
+    // let the user force a SPARQL expression string
+    case ' ':
+      return value.substr(1);
     // literal
     case '"':
       var match = value.match(/^"([^]*)"(?:(@.+)|\^\^(.+))?$/) || {},


### PR DESCRIPTION
I want to be able to create a SPARQL query without having an expression represented as an AST. eg:
```javascript
{ // ...
  where: {
    { type: 'filter',
      expression: 'regex(?var, "^match")',
    }
  }
}
```

But this yields:
```sparql
WHERE {
  # ...
  FILTER(<regex(?var,"^match")>)  # <= Not an IRI ref!
}
```

In fact, it would never make sense to have any filter have just an IRI ref. Instead of making the code check for this or adding much complication, why not just allow the user to bypass this?

This seems like a safe way to extend that functionality. Prefixing my string with a space could indicate I don't want entity conversion/handling. Aside from users forcing a string into the `expression` key, none of the other methods would ever call `toEntity` with a `value` having a space at the 0th character, so this addition is compatible with all other features. This is more of a patch than an API change.

Instead I could do this:
```javascript
{ // ...
  where: {
    { type: 'filter',
      expression: ' regex(?var, "^match")', // notice space character at beginning
    }
  }
}
```

Yielding:
```sparql
WHERE {
  # ...
  FILTER(regex(?var,"^match"))
}
```
