### PR TITLE
Values Clause vs Inline Data Block

### DIFF
--- a/lib/SparqlGenerator.js
+++ b/lib/SparqlGenerator.js
@@ -31,8 +31,6 @@ function toQuery(q) {
 
   if (q.updates)
     query += mapJoin(q.updates, toUpdate, ';\n');
-  else if (q.values)
-    query += patterns.values(q);
 
   if (q.group)
     query += 'GROUP BY ' + mapJoin(q.group, function (it) {
@@ -50,6 +48,9 @@ function toQuery(q) {
     query += 'OFFSET ' + q.offset + '\n';
   if (q.limit)
     query += 'LIMIT ' + q.limit + '\n';
+
+  if (q.values)
+    query += patterns.values(q);
   return query.trim();
 }
 

--- a/lib/sparql.jison
+++ b/lib/sparql.jison
@@ -478,6 +478,9 @@ LimitOffsetClauses
     | 'OFFSET' INTEGER 'LIMIT'  INTEGER -> { limit: toInt($4), offset: toInt($2) }
     ;
 ValuesClause
+    : 'VALUES' InlineData -> { values: $2 }
+    ;
+ValuesClauseInline
     : 'VALUES' InlineData -> { type: 'values', values: $2 }
     ;
 InlineData
@@ -611,7 +614,7 @@ GraphPatternNotTriples
     | 'SERVICE' 'SILENT'? (VAR | iri) GroupGraphPattern -> extend($4, { type: 'service', name: toVar($3), silent: !!$2 })
     | 'FILTER' Constraint -> { type: 'filter', expression: $2 }
     | 'BIND' '(' Expression 'AS' VAR ')' -> { type: 'bind', variable: toVar($5), expression: $3 }
-    | ValuesClause
+    | ValuesClauseInline
     ;
 Constraint
     : BrackettedExpression

--- a/queries/sparql-values-clause.sparql
+++ b/queries/sparql-values-clause.sparql
@@ -1,0 +1,13 @@
+PREFIX : <http://books.example/>
+SELECT (SUM(?lprice) AS ?totalPrice)
+WHERE {
+  ?org :affiliates ?auth .
+  ?auth :writesBook ?book .
+  ?book :price ?lprice .
+}
+GROUP BY ?org
+HAVING (SUM(?lprice) > 10)
+ORDER BY ?totalPrice
+VALUES (?book) { 
+     (:book2)
+   }

--- a/test/parsedQueries/sparql-10-2-2c.json
+++ b/test/parsedQueries/sparql-10-2-2c.json
@@ -1,5 +1,5 @@
 {
-  "type": "values",
+  "type": "query",
   "prefixes": {
     "dc": "http://purl.org/dc/elements/1.1/",
     "": "http://example.org/book/",

--- a/test/parsedQueries/sparql-fed-2-4c.json
+++ b/test/parsedQueries/sparql-fed-2-4c.json
@@ -1,5 +1,5 @@
 {
-  "type": "values",
+  "type": "query",
   "prefixes": {
     "foaf": "http://xmlns.com/foaf/0.1/",
     "": "http://example.org/"

--- a/test/parsedQueries/sparql-values-clause.json
+++ b/test/parsedQueries/sparql-values-clause.json
@@ -1,0 +1,70 @@
+{
+  "type": "query",
+  "prefixes": {
+    "": "http://books.example/"
+  },
+  "queryType": "SELECT",
+  "variables": [
+    {
+      "expression": {
+        "expression": "?lprice",
+        "type": "aggregate",
+        "aggregation": "sum",
+        "distinct": false
+      },
+      "variable": "?totalPrice"
+    }
+  ],
+  "where": [
+    {
+      "type": "bgp",
+      "triples": [
+        {
+          "subject": "?org",
+          "predicate": "http://books.example/affiliates",
+          "object": "?auth"
+        },
+        {
+          "subject": "?auth",
+          "predicate": "http://books.example/writesBook",
+          "object": "?book"
+        },
+        {
+          "subject": "?book",
+          "predicate": "http://books.example/price",
+          "object": "?lprice"
+        }
+      ]
+    }
+  ],
+  "group": [
+    {
+      "expression": "?org"
+    }
+  ],
+  "having": [
+    {
+      "type": "operation",
+      "operator": ">",
+      "args": [
+        {
+          "expression": "?lprice",
+          "type": "aggregate",
+          "aggregation": "sum",
+          "distinct": false
+        },
+        "\"10\"^^http://www.w3.org/2001/XMLSchema#integer"
+      ]
+    }
+  ],
+  "order": [
+    {
+      "expression": "?totalPrice"
+    }
+  ],
+  "values": [
+    {
+      "?book": "http://books.example/book2"
+    }
+  ]
+}


### PR DESCRIPTION
SPARQL 1.1 http://www.w3.org/TR/sparql11-query/#grammar  distinguishes between values clauses [28] and inline data blocks [61], with the difference that the values clause can also be used at end of the query or sub-select.

This PR is to add the distinction to the jison grammar. A simple test case for values clause at the end of the query is provided and two existing test cases are being fixed.