### PR TITLE
Preserve FILTER clause position when parsing query.

### DIFF
--- a/lib/sparql.jison
+++ b/lib/sparql.jison
@@ -573,9 +573,9 @@ GroupGraphPattern
     : '{' SubSelect '}' -> $2
     | '{' GroupGraphPatternSub '}'
     {
-      // Simplify the groups by merging adjacent BGPs and moving filters to the back
+      // Simplify the groups by merging adjacent BGPs
       if ($2.length > 1) {
-        var groups = [], currentBgp, filters = [];
+        var groups = [], currentBgp;
         for (var i = 0, group; group=$2[i]; i++) {
           switch (group.type) {
             // Add a BGP's triples to the current BGP
@@ -587,10 +587,6 @@ GroupGraphPattern
                   appendAllTo(currentBgp.triples, group.triples);
               }
               break;
-            // Save filters separately
-            case 'filter':
-              appendTo(filters, group);
-              break;
             // All other groups break up a BGP
             default:
               // Only add the group if its pattern is non-empty
@@ -600,7 +596,7 @@ GroupGraphPattern
               }
           }
         }
-        $2 = appendAllTo(groups, filters);
+        $2 = groups;
       }
       $$ = { type: 'group', patterns: $2 }
     }

--- a/test/SparqlParser-test.js
+++ b/test/SparqlParser-test.js
@@ -37,6 +37,15 @@ describe('A SPARQL parser', function () {
     expect(error.message).to.include('Parse error on line 1');
   });
 
+  it('should preserve BGP and filter pattern order', function () {
+    var parser = new SparqlParser();
+    var query = 'SELECT * { ?s ?p "1" . FILTER(true) . ?s ?p "2"  }';
+    var groups = parser.parse(query).where;
+    expect(groups[0].type).to.equal("bgp");
+    expect(groups[1].type).to.equal("filter");
+    expect(groups[2].type).to.equal("bgp");
+  });
+
   describe('with pre-defined prefixes', function () {
     var prefixes = { a: 'ex:abc#', b: 'ex:def#' };
     var parser = new SparqlParser(prefixes);

--- a/test/parsedQueries/bsbm10.json
+++ b/test/parsedQueries/bsbm10.json
@@ -39,16 +39,6 @@
           "subject": "?offer",
           "predicate": "http://www4.wiwiss.fu-berlin.de/bizer/bsbm/v01/vocabulary/deliveryDays",
           "object": "?deliveryDays"
-        },
-        {
-          "subject": "?offer",
-          "predicate": "http://www4.wiwiss.fu-berlin.de/bizer/bsbm/v01/vocabulary/price",
-          "object": "?price"
-        },
-        {
-          "subject": "?offer",
-          "predicate": "http://www4.wiwiss.fu-berlin.de/bizer/bsbm/v01/vocabulary/validTo",
-          "object": "?date"
         }
       ]
     },
@@ -62,6 +52,21 @@
           "\"3\"^^http://www.w3.org/2001/XMLSchema#integer"
         ]
       }
+    },
+    {
+      "type": "bgp",
+      "triples": [
+        {
+          "subject": "?offer",
+          "predicate": "http://www4.wiwiss.fu-berlin.de/bizer/bsbm/v01/vocabulary/price",
+          "object": "?price"
+        },
+        {
+          "subject": "?offer",
+          "predicate": "http://www4.wiwiss.fu-berlin.de/bizer/bsbm/v01/vocabulary/validTo",
+          "object": "?date"
+        }
+      ]
     },
     {
       "type": "filter",

--- a/test/parsedQueries/bsbm5.json
+++ b/test/parsedQueries/bsbm5.json
@@ -19,7 +19,23 @@
           "subject": "?product",
           "predicate": "http://www.w3.org/2000/01/rdf-schema#label",
           "object": "?productLabel"
-        },
+        }
+      ]
+    },
+    {
+      "type": "filter",
+      "expression": {
+        "type": "operation",
+        "operator": "!=",
+        "args": [
+          "http://www4.wiwiss.fu-berlin.de/bizer/bsbm/v01/instances/dataFromProducer1/Product28",
+          "?product"
+        ]
+      }
+    },
+    {
+      "type": "bgp",
+      "triples": [
         {
           "subject": "http://www4.wiwiss.fu-berlin.de/bizer/bsbm/v01/instances/dataFromProducer1/Product28",
           "predicate": "http://www4.wiwiss.fu-berlin.de/bizer/bsbm/v01/vocabulary/productFeature",
@@ -39,29 +55,8 @@
           "subject": "?product",
           "predicate": "http://www4.wiwiss.fu-berlin.de/bizer/bsbm/v01/vocabulary/productPropertyNumeric1",
           "object": "?simProperty1"
-        },
-        {
-          "subject": "http://www4.wiwiss.fu-berlin.de/bizer/bsbm/v01/instances/dataFromProducer1/Product28",
-          "predicate": "http://www4.wiwiss.fu-berlin.de/bizer/bsbm/v01/vocabulary/productPropertyNumeric2",
-          "object": "?origProperty2"
-        },
-        {
-          "subject": "?product",
-          "predicate": "http://www4.wiwiss.fu-berlin.de/bizer/bsbm/v01/vocabulary/productPropertyNumeric2",
-          "object": "?simProperty2"
         }
       ]
-    },
-    {
-      "type": "filter",
-      "expression": {
-        "type": "operation",
-        "operator": "!=",
-        "args": [
-          "http://www4.wiwiss.fu-berlin.de/bizer/bsbm/v01/instances/dataFromProducer1/Product28",
-          "?product"
-        ]
-      }
     },
     {
       "type": "filter",
@@ -101,6 +96,21 @@
           }
         ]
       }
+    },
+    {
+      "type": "bgp",
+      "triples": [
+        {
+          "subject": "http://www4.wiwiss.fu-berlin.de/bizer/bsbm/v01/instances/dataFromProducer1/Product28",
+          "predicate": "http://www4.wiwiss.fu-berlin.de/bizer/bsbm/v01/vocabulary/productPropertyNumeric2",
+          "object": "?origProperty2"
+        },
+        {
+          "subject": "?product",
+          "predicate": "http://www4.wiwiss.fu-berlin.de/bizer/bsbm/v01/vocabulary/productPropertyNumeric2",
+          "object": "?simProperty2"
+        }
+      ]
     },
     {
       "type": "filter",

--- a/test/parsedQueries/bsbm8.json
+++ b/test/parsedQueries/bsbm8.json
@@ -36,7 +36,29 @@
           "subject": "?review",
           "predicate": "http://purl.org/stuff/rev#text",
           "object": "?text"
-        },
+        }
+      ]
+    },
+    {
+      "type": "filter",
+      "expression": {
+        "type": "operation",
+        "operator": "langmatches",
+        "args": [
+          {
+            "type": "operation",
+            "operator": "lang",
+            "args": [
+              "?text"
+            ]
+          },
+          "\"EN\""
+        ]
+      }
+    },
+    {
+      "type": "bgp",
+      "triples": [
         {
           "subject": "?review",
           "predicate": "http://www4.wiwiss.fu-berlin.de/bizer/bsbm/v01/vocabulary/reviewDate",
@@ -113,23 +135,6 @@
           ]
         }
       ]
-    },
-    {
-      "type": "filter",
-      "expression": {
-        "type": "operation",
-        "operator": "langmatches",
-        "args": [
-          {
-            "type": "operation",
-            "operator": "lang",
-            "args": [
-              "?text"
-            ]
-          },
-          "\"EN\""
-        ]
-      }
     }
   ],
   "order": [

--- a/test/parsedQueries/sparql-10-1a.json
+++ b/test/parsedQueries/sparql-10-1a.json
@@ -45,16 +45,6 @@
       }
     },
     {
-      "type": "bgp",
-      "triples": [
-        {
-          "subject": "?x",
-          "predicate": "http://purl.org/dc/elements/1.1/title",
-          "object": "?title"
-        }
-      ]
-    },
-    {
       "type": "filter",
       "expression": {
         "type": "operation",
@@ -64,6 +54,16 @@
           "\"20\"^^http://www.w3.org/2001/XMLSchema#integer"
         ]
       }
+    },
+    {
+      "type": "bgp",
+      "triples": [
+        {
+          "subject": "?x",
+          "predicate": "http://purl.org/dc/elements/1.1/title",
+          "object": "?title"
+        }
+      ]
     }
   ]
 }

--- a/test/parsedQueries/sparql-5-2-2b.json
+++ b/test/parsedQueries/sparql-5-2-2b.json
@@ -10,6 +10,17 @@
   ],
   "where": [
     {
+      "type": "filter",
+      "expression": {
+        "type": "operation",
+        "operator": "regex",
+        "args": [
+          "?name",
+          "\"Smith\""
+        ]
+      }
+    },
+    {
       "type": "bgp",
       "triples": [
         {
@@ -23,17 +34,6 @@
           "object": "?mbox"
         }
       ]
-    },
-    {
-      "type": "filter",
-      "expression": {
-        "type": "operation",
-        "operator": "regex",
-        "args": [
-          "?name",
-          "\"Smith\""
-        ]
-      }
     }
   ]
 }

--- a/test/parsedQueries/sparql-5-2-2c.json
+++ b/test/parsedQueries/sparql-5-2-2c.json
@@ -16,11 +16,6 @@
           "subject": "?x",
           "predicate": "http://xmlns.com/foaf/0.1/name",
           "object": "?name"
-        },
-        {
-          "subject": "?x",
-          "predicate": "http://xmlns.com/foaf/0.1/mbox",
-          "object": "?mbox"
         }
       ]
     },
@@ -34,6 +29,16 @@
           "\"Smith\""
         ]
       }
+    },
+    {
+      "type": "bgp",
+      "triples": [
+        {
+          "subject": "?x",
+          "predicate": "http://xmlns.com/foaf/0.1/mbox",
+          "object": "?mbox"
+        }
+      ]
     }
   ]
 }

--- a/test/parsedQueries/sparql-5-2-3b.json
+++ b/test/parsedQueries/sparql-5-2-3b.json
@@ -16,11 +16,6 @@
           "subject": "?x",
           "predicate": "http://xmlns.com/foaf/0.1/name",
           "object": "?name"
-        },
-        {
-          "subject": "?x",
-          "predicate": "http://xmlns.com/foaf/0.1/mbox",
-          "object": "?mbox"
         }
       ]
     },
@@ -34,6 +29,16 @@
           "\"Smith\""
         ]
       }
+    },
+    {
+      "type": "bgp",
+      "triples": [
+        {
+          "subject": "?x",
+          "predicate": "http://xmlns.com/foaf/0.1/mbox",
+          "object": "?mbox"
+        }
+      ]
     }
   ]
 }

--- a/test/parsedQueries/sparql-9-2g.json
+++ b/test/parsedQueries/sparql-9-2g.json
@@ -27,11 +27,6 @@
             ]
           },
           "object": "?y"
-        },
-        {
-          "subject": "?y",
-          "predicate": "http://xmlns.com/foaf/0.1/name",
-          "object": "?name"
         }
       ]
     },
@@ -45,6 +40,16 @@
           "?y"
         ]
       }
+    },
+    {
+      "type": "bgp",
+      "triples": [
+        {
+          "subject": "?y",
+          "predicate": "http://xmlns.com/foaf/0.1/name",
+          "object": "?name"
+        }
+      ]
     }
   ]
 }

--- a/test/parsedQueries/sparql-fed-4.json
+++ b/test/parsedQueries/sparql-fed-4.json
@@ -27,6 +27,17 @@
       ]
     },
     {
+      "type": "filter",
+      "expression": {
+        "type": "operation",
+        "operator": "regex",
+        "args": [
+          "?projectSubject",
+          "\"remote\""
+        ]
+      }
+    },
+    {
       "type": "service",
       "patterns": [
         {
@@ -42,17 +53,6 @@
       ],
       "name": "?service",
       "silent": false
-    },
-    {
-      "type": "filter",
-      "expression": {
-        "type": "operation",
-        "operator": "regex",
-        "args": [
-          "?projectSubject",
-          "\"remote\""
-        ]
-      }
     }
   ]
 }

--- a/test/parsedQueries/sparql-update-3-1-3-1a.json
+++ b/test/parsedQueries/sparql-update-3-1-3-1a.json
@@ -28,11 +28,6 @@
               "subject": "?book",
               "predicate": "http://purl.org/dc/elements/1.1/date",
               "object": "?date"
-            },
-            {
-              "subject": "?book",
-              "predicate": "?p",
-              "object": "?v"
             }
           ]
         },
@@ -46,6 +41,16 @@
               "\"1970-01-01T00:00:00-02:00\"^^http://www.w3.org/2001/XMLSchema#dateTime"
             ]
           }
+        },
+        {
+          "type": "bgp",
+          "triples": [
+            {
+              "subject": "?book",
+              "predicate": "?p",
+              "object": "?v"
+            }
+          ]
         }
       ]
     }

--- a/test/parsedQueries/sparql-update-3-1-3-2a.json
+++ b/test/parsedQueries/sparql-update-3-1-3-2a.json
@@ -32,11 +32,6 @@
                   "subject": "?book",
                   "predicate": "http://purl.org/dc/elements/1.1/date",
                   "object": "?date"
-                },
-                {
-                  "subject": "?book",
-                  "predicate": "?p",
-                  "object": "?v"
                 }
               ]
             },
@@ -50,6 +45,16 @@
                   "\"1970-01-01T00:00:00-02:00\"^^http://www.w3.org/2001/XMLSchema#dateTime"
                 ]
               }
+            },
+            {
+              "type": "bgp",
+              "triples": [
+                {
+                  "subject": "?book",
+                  "predicate": "?p",
+                  "object": "?v"
+                }
+              ]
             }
           ],
           "name": "http://example/bookStore"

--- a/test/parsedQueries/sparql-update-3-1-3-2c.json
+++ b/test/parsedQueries/sparql-update-3-1-3-2c.json
@@ -33,11 +33,6 @@
                   "subject": "?book",
                   "predicate": "http://purl.org/dc/elements/1.1/date",
                   "object": "?date"
-                },
-                {
-                  "subject": "?book",
-                  "predicate": "?p",
-                  "object": "?v"
                 }
               ]
             },
@@ -51,6 +46,16 @@
                   "\"2000-01-01T00:00:00-02:00\"^^http://www.w3.org/2001/XMLSchema#dateTime"
                 ]
               }
+            },
+            {
+              "type": "bgp",
+              "triples": [
+                {
+                  "subject": "?book",
+                  "predicate": "?p",
+                  "object": "?v"
+                }
+              ]
             }
           ],
           "name": "http://example/bookStore"
@@ -86,11 +91,6 @@
               "subject": "?book",
               "predicate": "http://purl.org/dc/elements/1.1/type",
               "object": "http://purl.org/dc/dcmitype/PhysicalObject"
-            },
-            {
-              "subject": "?book",
-              "predicate": "?p",
-              "object": "?v"
             }
           ]
         },
@@ -104,6 +104,16 @@
               "\"2000-01-01T00:00:00-02:00\"^^http://www.w3.org/2001/XMLSchema#dateTime"
             ]
           }
+        },
+        {
+          "type": "bgp",
+          "triples": [
+            {
+              "subject": "?book",
+              "predicate": "?p",
+              "object": "?v"
+            }
+          ]
         }
       ]
     }


### PR DESCRIPTION
This PR removes special case for `FILTER` when reducing `GroupGraphPattern`.

For example, without this changes the following query
```
SELECT * WHERE {
  ?s ?p ?o .
  FILTER(?o != "foo")
  OPTIONAL { ?s a ?t }
}
```
will become
```
SELECT * WHERE {
  ?s ?p ?o .
  OPTIONAL { ?s a ?t }
  FILTER(?o != "foo")
}
```
after parse -> stringify.

The problem is [order matters in SPARQL](https://wiki.blazegraph.com/wiki/index.php/SPARQL_Order_Matters). In our case, OPTIONAL <-> JOIN reordering causes significant performance issues because database cannot properly optimize latter query.