### PR TITLE
Add space before . (dot) when serializing triple

### DIFF
--- a/lib/SparqlGenerator.js
+++ b/lib/SparqlGenerator.js
@@ -66,7 +66,11 @@ function toPattern(pattern) {
 }
 var patterns = {
   triple: function (t) {
-    return toEntity(t.subject) + ' ' + toEntity(t.predicate) + ' ' + toEntity(t.object) + '.';
+    var objectEntity = toEntity(t.object);
+    // prevent syntax error in SPARQL 1.0 parsers when dot after a triple
+    // parsed as decimal separator instead of triple separator
+    if (isDigitSequence(objectEntity)) { objectEntity += ' '; }
+    return toEntity(t.subject) + ' ' + toEntity(t.predicate) + ' ' + objectEntity + '.';
   },
   array: function (items) {
     return mapJoin(items, toPattern, '\n');
@@ -191,7 +195,7 @@ function toEntity(value) {
           lexical = match[1] || '', language = match[2] || '', datatype = match[3];
       value = '"' + lexical.replace(escape, escapeReplacer) + '"' + language;
       if (datatype) {
-        if (datatype === XSD_INTEGER && /^\d+$/.test(lexical)) return lexical;
+        if (datatype === XSD_INTEGER && isDigitSequence(lexical)) return lexical;
         value += '^^<' + datatype + '>';
       }
       return value;
@@ -253,6 +257,8 @@ function toUpdate(update) {
 
 // Checks whether the object is a string
 function isString(object) { return typeof object === 'string'; }
+
+function isDigitSequence(text) { return /^\d+$/.test(text); }
 
 // Maps the array with the given function, and joins the results using the separator
 function mapJoin(array, func, sep) { return array.map(func).join(isString(sep) ? sep : ' '); }


### PR DESCRIPTION
When serializing a query with triple that contains `xsd:integer` in an object position, currently it's being serialized as `n.`

While it's technically correct by the specification, it's still preferable to serialize it as `n .` because there are some broken triplestore parsers.