### PR TITLE
Use prefixes when generating IRIs in SPARQL, add an option to remove unused prefixes

### DIFF
--- a/lib/SparqlGenerator.js
+++ b/lib/SparqlGenerator.js
@@ -1,13 +1,32 @@
 var XSD_INTEGER = 'http://www.w3.org/2001/XMLSchema#integer';
 
-module.exports = function SparqlGenerator() {
+/**
+ * @param options {
+ *   allPrefixes: boolean
+ * }
+ */
+module.exports = function SparqlGenerator(options) {
   return {
-    stringify: function (q) { return new Generator(q.prefixes).toQuery(q); }
+    stringify: function (q) { return new Generator(options, q.prefixes).toQuery(q); }
   };
 };
 
-function Generator(prefixes) {
-  this.prefixes = prefixes || {};
+function Generator(options, prefixes) {
+  this.options = options || {};
+
+  prefixes = prefixes || {};
+  var prefixesArray = Object.keys(prefixes);
+  var iriList = prefixesArray
+    .map(function (prefix) { return prefixes[prefix] })
+    .join('|')
+    .replace(/[\]\/\(\)\*\+\?\.\\\$]/g, '\\$&');
+  this.prefixRegex = new RegExp('^(' + iriList + ')[a-zA-Z][\\-_a-zA-Z0-9]*$', 'g');
+  this.prefixByIri = prefixesArray.reduce(function (acc, prefix) {
+    acc[prefixes[prefix]] = prefix;
+    return acc;
+  }, {});
+  this.usedPrefixes = {};
+
   this.patterns = {};
   for (var key in PATTERNS) {
     this.patterns[key] = PATTERNS[key].bind(this);
@@ -17,10 +36,6 @@ function Generator(prefixes) {
 // Converts the parsed query object into a SPARQL query
 Generator.prototype.toQuery = function (q) {
   var query = '';
-  if (q.base)
-    query += 'BASE <' + q.base + '>\n';
-  for (var key in q.prefixes)
-    query += 'PREFIX ' + key + ': <' + q.prefixes[key] + '>\n';
 
   if (q.queryType)
     query += q.queryType.toUpperCase() + ' ';
@@ -65,7 +80,20 @@ Generator.prototype.toQuery = function (q) {
 
   if (q.values)
     query += this.patterns.values(q);
+
+  // stringify prefixes at the end to mark used ones
+  query = this.baseAndPrefixes(q) + query;
   return query.trim();
+}
+
+Generator.prototype.baseAndPrefixes = function (q) {
+  var base = q.base ? ('BASE <' + q.base + '>\n') : '';
+  var prefixes = '';
+  for (var key in q.prefixes) {
+    if (!this.options.allPrefixes && !this.usedPrefixes[key]) { continue; }
+    prefixes += 'PREFIX ' + key + ': <' + q.prefixes[key] + '>\n';
+  }
+  return base + prefixes;
 }
 
 // Converts the parsed SPARQL pattern into a SPARQL pattern
@@ -206,12 +234,12 @@ Generator.prototype.toEntity = function (value) {
         if (datatype === XSD_INTEGER && /^\d+$/.test(lexical))
           // Add space to avoid confusion with decimals in broken parsers
           return lexical + ' ';
-        value += '^^<' + datatype + '>';
+        value += '^^' + this.encodeIRI(datatype);
       }
       return value;
     // IRI
     default:
-      return '<' + value + '>';
+      return this.encodeIRI(value);
     }
   }
   // property path
@@ -237,6 +265,26 @@ var escape = /["\\\t\n\r\b\f]/g,
     escapeReplacer = function (c) { return escapeReplacements[c]; },
     escapeReplacements = { '\\': '\\\\', '"': '\\"', '\t': '\\t',
                            '\n': '\\n', '\r': '\\r', '\b': '\\b', '\f': '\\f' };
+
+Generator.prototype.encodeIRI = function (iri) {
+  // try to represent the IRI as prefixed name
+  this.prefixRegex.lastIndex = 0;
+  var prefixMatch, longestPrefix, prefixLength = -1;
+  while (prefixMatch = this.prefixRegex.exec(iri)) {
+    const matchedPrefixIRI = prefixMatch[1];
+    if (matchedPrefixIRI.length > prefixLength) {
+      longestPrefix = this.prefixByIri[matchedPrefixIRI];
+      prefixLength = matchedPrefixIRI.length;
+    }
+  }
+
+  if (longestPrefix !== undefined) {
+    this.usedPrefixes[longestPrefix] = true;
+    return longestPrefix + ':' + iri.substring(prefixLength);
+  }
+
+  return '<' + iri + '>';
+}
 
 // Converts the parsed update object into a SPARQL update clause
 Generator.prototype.toUpdate = function (update) {

--- a/lib/SparqlGenerator.js
+++ b/lib/SparqlGenerator.js
@@ -1,9 +1,21 @@
 var XSD_INTEGER = 'http://www.w3.org/2001/XMLSchema#integer';
 
-module.exports = function SparqlGenerator() { return { stringify: toQuery }; };
+module.exports = function SparqlGenerator() {
+  return {
+    stringify: function (q) { return new Generator(q.prefixes).toQuery(q); }
+  };
+};
+
+function Generator(prefixes) {
+  this.prefixes = prefixes || {};
+  this.patterns = {};
+  for (var key in PATTERNS) {
+    this.patterns[key] = PATTERNS[key].bind(this);
+  }
+}
 
 // Converts the parsed query object into a SPARQL query
-function toQuery(q) {
+Generator.prototype.toQuery = function (q) {
   var query = '';
   if (q.base)
     query += 'BASE <' + q.base + '>\n';
@@ -18,33 +30,33 @@ function toQuery(q) {
     query += 'DISTINCT ';
 
   if (q.variables)
-    query += mapJoin(q.variables, function (variable) {
-      return isString(variable) ? toEntity(variable) :
-             '(' + toExpression(variable.expression) + ' AS ' + variable.variable + ')';
-    }) + ' ';
+    query += mapJoin(q.variables, undefined, function (variable) {
+      return isString(variable) ? this.toEntity(variable) :
+             '(' + this.toExpression(variable.expression) + ' AS ' + variable.variable + ')';
+    }, this) + ' ';
   else if (q.template)
-    query += patterns.group(q.template, true) + '\n';
+    query += this.patterns.group(q.template, true) + '\n';
 
   if (q.from)
-    query += mapJoin(q.from.default || [], function (g) { return 'FROM ' + toEntity(g) + '\n'; }, '') +
-             mapJoin(q.from.named || [], function (g) { return 'FROM NAMED ' + toEntity(g) + '\n'; }, '');
+    query += mapJoin(q.from.default || [], '', function (g) { return 'FROM ' + this.toEntity(g) + '\n'; }, this) +
+             mapJoin(q.from.named || [], '', function (g) { return 'FROM NAMED ' + this.toEntity(g) + '\n'; }, this);
   if (q.where)
-    query += 'WHERE ' + patterns.group(q.where, true)  + '\n';
+    query += 'WHERE ' + this.patterns.group(q.where, true)  + '\n';
 
   if (q.updates)
-    query += mapJoin(q.updates, toUpdate, ';\n');
+    query += mapJoin(q.updates, ';\n', this.toUpdate, this);
 
   if (q.group)
-    query += 'GROUP BY ' + mapJoin(q.group, function (it) {
-      return isString(it.expression) ? it.expression : '(' + toExpression(it.expression) + ')';
-    }) + '\n';
+    query += 'GROUP BY ' + mapJoin(q.group, undefined, function (it) {
+      return isString(it.expression) ? it.expression : '(' + this.toExpression(it.expression) + ')';
+    }, this) + '\n';
   if (q.having)
-    query += 'HAVING (' + mapJoin(q.having, toExpression) + ')\n';
+    query += 'HAVING (' + mapJoin(q.having, undefined, this.toExpression, this) + ')\n';
   if (q.order)
-    query += 'ORDER BY ' + mapJoin(q.order, function (it) {
-      var expr = toExpression(it.expression);
+    query += 'ORDER BY ' + mapJoin(q.order, undefined, function (it) {
+      var expr = this.toExpression(it.expression);
       return !it.descending ? expr : 'DESC(' + expr + ')';
-    }) + '\n';
+    }, this) + '\n';
 
   if (q.offset)
     query += 'OFFSET ' + q.offset + '\n';
@@ -52,53 +64,53 @@ function toQuery(q) {
     query += 'LIMIT ' + q.limit + '\n';
 
   if (q.values)
-    query += patterns.values(q);
+    query += this.patterns.values(q);
   return query.trim();
 }
 
 // Converts the parsed SPARQL pattern into a SPARQL pattern
-function toPattern(pattern) {
+Generator.prototype.toPattern = function (pattern) {
   var type = pattern.type || (pattern instanceof Array) && 'array' ||
              (pattern.subject && pattern.predicate && pattern.object ? 'triple' : '');
-  if (!(type in patterns))
+  if (!(type in this.patterns))
     throw new Error('Unknown entry type: ' + type);
-  return patterns[type](pattern);
+  return this.patterns[type](pattern);
 }
-var patterns = {
+var PATTERNS = {
   triple: function (t) {
-    return toEntity(t.subject) + ' ' + toEntity(t.predicate) + ' ' + toEntity(t.object) + '.';
+    return this.toEntity(t.subject) + ' ' + this.toEntity(t.predicate) + ' ' + this.toEntity(t.object) + '.';
   },
   array: function (items) {
-    return mapJoin(items, toPattern, '\n');
+    return mapJoin(items, '\n', this.toPattern, this);
   },
   bgp: function (bgp) {
-    return mapJoin(bgp.triples, patterns.triple, '\n');
+    return mapJoin(bgp.triples, '\n', this.patterns.triple, this);
   },
   graph: function (graph) {
-    return 'GRAPH ' + toEntity(graph.name) + ' ' + patterns.group(graph);
+    return 'GRAPH ' + this.toEntity(graph.name) + ' ' + this.patterns.group(graph);
   },
   group: function (group, inline) {
-    group = inline !== true ? patterns.array(group.patterns || group.triples)
-                            : toPattern(group.type !== 'group' ? group : group.patterns);
+    group = inline !== true ? this.patterns.array(group.patterns || group.triples)
+                            : this.toPattern(group.type !== 'group' ? group : group.patterns);
     return group.indexOf('\n') === -1 ? '{ ' + group + ' }' : '{\n' + indent(group) + '\n}';
   },
   query: function (query) {
-    return '{\n' + indent(toQuery(query)) + '\n}';
+    return '{\n' + indent(this.toQuery(query)) + '\n}';
   },
   filter: function (filter) {
-    return 'FILTER(' + toExpression(filter.expression) + ')';
+    return 'FILTER(' + this.toExpression(filter.expression) + ')';
   },
   bind: function (bind) {
-    return 'BIND(' + toExpression(bind.expression) + ' AS ' + bind.variable + ')';
+    return 'BIND(' + this.toExpression(bind.expression) + ' AS ' + bind.variable + ')';
   },
   optional: function (optional) {
-    return 'OPTIONAL ' + patterns.group(optional);
+    return 'OPTIONAL ' + this.patterns.group(optional);
   },
   union: function (union) {
-    return mapJoin(union.patterns, function (p) { return patterns.group(p, true); }, '\nUNION\n');
+    return mapJoin(union.patterns, '\nUNION\n', function (p) { return this.patterns.group(p, true); }, this);
   },
   minus: function (minus) {
-    return 'MINUS ' + patterns.group(minus);
+    return 'MINUS ' + this.patterns.group(minus);
   },
   values: function (valuesList) {
     // Gather unique keys
@@ -108,30 +120,30 @@ var patterns = {
     }, {}));
     // Create value rows
     return 'VALUES (' + keys.join(' ') + ') {\n' +
-      mapJoin(valuesList.values, function (values) {
-        return '  (' + mapJoin(keys, function (key) {
-          return values[key] !== undefined ? toEntity(values[key]) : 'UNDEF';
-        }) + ')';
-      }, '\n') + '\n}';
+      mapJoin(valuesList.values, '\n', function (values) {
+        return '  (' + mapJoin(keys, undefined, function (key) {
+          return values[key] !== undefined ? this.toEntity(values[key]) : 'UNDEF';
+        }, this) + ')';
+      }, this) + '\n}';
   },
   service: function (service) {
-    return 'SERVICE ' + (service.silent ? 'SILENT ' : '') + toEntity(service.name) + ' ' +
-           patterns.group(service);
+    return 'SERVICE ' + (service.silent ? 'SILENT ' : '') + this.toEntity(service.name) + ' ' +
+           this.patterns.group(service);
   },
 };
 
 // Converts the parsed expression object into a SPARQL expression
-function toExpression(expr) {
+Generator.prototype.toExpression = function (expr) {
   if (isString(expr))
-    return toEntity(expr);
+    return this.toEntity(expr);
 
   switch (expr.type.toLowerCase()) {
     case 'aggregate':
       return expr.aggregation.toUpperCase() +
-             '(' + (expr.distinct ? 'DISTINCT ' : '') + toExpression(expr.expression) +
-             (expr.separator ? '; SEPARATOR = ' + toEntity('"' + expr.separator + '"') : '') + ')';
+             '(' + (expr.distinct ? 'DISTINCT ' : '') + this.toExpression(expr.expression) +
+             (expr.separator ? '; SEPARATOR = ' + this.toEntity('"' + expr.separator + '"') : '') + ')';
     case 'functioncall':
-      return toEntity(expr.function) + '(' + mapJoin(expr.args, toExpression, ', ') + ')';
+      return this.toEntity(expr.function) + '(' + mapJoin(expr.args, ', ', this.toExpression, this) + ')';
     case 'operation':
       var operator = expr.operator.toUpperCase(), args = expr.args || [];
       switch (expr.operator.toLowerCase()) {
@@ -148,26 +160,26 @@ function toExpression(expr) {
       case '-':
       case '*':
       case '/':
-          return (isString(args[0]) ? toEntity(args[0]) : '(' + toExpression(args[0]) + ')') +
+          return (isString(args[0]) ? this.toEntity(args[0]) : '(' + this.toExpression(args[0]) + ')') +
                  ' ' + operator + ' ' +
-                 (isString(args[1]) ? toEntity(args[1]) : '(' + toExpression(args[1]) + ')');
+                 (isString(args[1]) ? this.toEntity(args[1]) : '(' + this.toExpression(args[1]) + ')');
       // Unary operators
       case '!':
-        return '!' + toExpression(args[0]);
+        return '!' + this.toExpression(args[0]);
       // IN and NOT IN
       case 'notin':
         operator = 'NOT IN';
       case 'in':
-        return toExpression(args[0]) + ' ' + operator +
-               '(' + (isString(args[1]) ? args[1] : mapJoin(args[1], toExpression, ', ')) + ')';
+        return this.toExpression(args[0]) + ' ' + operator +
+               '(' + (isString(args[1]) ? args[1] : mapJoin(args[1], ', ', this.toExpression, this)) + ')';
       // EXISTS and NOT EXISTS
       case 'notexists':
         operator = 'NOT EXISTS';
       case 'exists':
-        return operator + ' ' + patterns.group(args[0], true);
+        return operator + ' ' + this.patterns.group(args[0], true);
       // Other expressions
       default:
-        return operator + '(' + mapJoin(args, toExpression, ', ') + ')';
+        return operator + '(' + mapJoin(args, ', ', this.toExpression, this) + ')';
       }
     default:
       throw new Error('Unknown expression type: ' + expr.type);
@@ -175,7 +187,7 @@ function toExpression(expr) {
 }
 
 // Converts the parsed entity (or property path) into a SPARQL entity
-function toEntity(value) {
+Generator.prototype.toEntity = function (value) {
   // regular entity
   if (isString(value)) {
     switch (value[0]) {
@@ -204,7 +216,7 @@ function toEntity(value) {
   }
   // property path
   else {
-    var items = value.items.map(toEntity), path = value.pathType;
+    var items = value.items.map(this.toEntity, this), path = value.pathType;
     switch (path) {
     // prefix operator
     case '^':
@@ -227,27 +239,27 @@ var escape = /["\\\t\n\r\b\f]/g,
                            '\n': '\\n', '\r': '\\r', '\b': '\\b', '\f': '\\f' };
 
 // Converts the parsed update object into a SPARQL update clause
-function toUpdate(update) {
+Generator.prototype.toUpdate = function (update) {
   switch (update.type || update.updateType) {
   case 'load':
-    return 'LOAD' + (update.source ? ' ' + toEntity(update.source) : '') +
-           (update.destination ? ' INTO GRAPH ' + toEntity(update.destination) : '');
+    return 'LOAD' + (update.source ? ' ' + this.toEntity(update.source) : '') +
+           (update.destination ? ' INTO GRAPH ' + this.toEntity(update.destination) : '');
   case 'insert':
-    return 'INSERT DATA '  + patterns.group(update.insert, true);
+    return 'INSERT DATA '  + this.patterns.group(update.insert, true);
   case 'delete':
-    return 'DELETE DATA '  + patterns.group(update.delete, true);
+    return 'DELETE DATA '  + this.patterns.group(update.delete, true);
   case 'deletewhere':
-    return 'DELETE WHERE ' + patterns.group(update.delete, true);
+    return 'DELETE WHERE ' + this.patterns.group(update.delete, true);
   case 'insertdelete':
-    return (update.graph ? 'WITH ' + toEntity(update.graph) + '\n' : '') +
-           (update.delete.length ? 'DELETE ' + patterns.group(update.delete, true) + '\n' : '') +
-           (update.insert.length ? 'INSERT ' + patterns.group(update.insert, true) + '\n' : '') +
-           'WHERE ' + patterns.group(update.where, true);
+    return (update.graph ? 'WITH ' + this.toEntity(update.graph) + '\n' : '') +
+           (update.delete.length ? 'DELETE ' + this.patterns.group(update.delete, true) + '\n' : '') +
+           (update.insert.length ? 'INSERT ' + this.patterns.group(update.insert, true) + '\n' : '') +
+           'WHERE ' + this.patterns.group(update.where, true);
   case 'add':
   case 'copy':
   case 'move':
     return update.type.toUpperCase() + (update.source.default ? ' DEFAULT ' : ' ') +
-           'TO ' + toEntity(update.destination.name);
+           'TO ' + this.toEntity(update.destination.name);
   default:
     throw new Error('Unknown update query type: ' + update.type);
   }
@@ -257,7 +269,9 @@ function toUpdate(update) {
 function isString(object) { return typeof object === 'string'; }
 
 // Maps the array with the given function, and joins the results using the separator
-function mapJoin(array, func, sep) { return array.map(func).join(isString(sep) ? sep : ' '); }
+function mapJoin(array, sep, func, self) {
+  return array.map(func, self).join(isString(sep) ? sep : ' ');
+}
 
 // Indents each line of the string
 function indent(text) { return text.replace(/^/gm, '  '); }

--- a/test/unusedPrefixes/unused-prefixes-1.json
+++ b/test/unusedPrefixes/unused-prefixes-1.json
@@ -1,0 +1,25 @@
+{
+  "type": "query",
+  "prefixes": {
+    "dc": "http://purl.org/dc/elements/1.1/",
+    "schema": "http://schema.org/",
+    "xsd": "http://www.w3.org/2001/XMLSchema",
+    "": "http://example.org/book/"
+  },
+  "queryType": "SELECT",
+  "variables": [
+    "?title"
+  ],
+  "where": [
+    {
+      "type": "bgp",
+      "triples": [
+        {
+          "subject": "http://example.org/book/book1",
+          "predicate": "http://purl.org/dc/elements/1.1/title",
+          "object": "?title"
+        }
+      ]
+    }
+  ]
+}

--- a/test/unusedPrefixes/unused-prefixes-1.sparql
+++ b/test/unusedPrefixes/unused-prefixes-1.sparql
@@ -1,0 +1,3 @@
+PREFIX dc: <http://purl.org/dc/elements/1.1/>
+PREFIX : <http://example.org/book/>
+SELECT ?title WHERE { :book1 dc:title ?title. }

--- a/test/unusedPrefixes/unused-prefixes-2.json
+++ b/test/unusedPrefixes/unused-prefixes-2.json
@@ -1,0 +1,25 @@
+{
+  "type": "query",
+  "prefixes": {
+    "dc": "http://purl.org/dc/elements/1.1/",
+    "schema": "http://schema.org/",
+    "xsd": "http://www.w3.org/2001/XMLSchema",
+    "": "http://example.org/book/"
+  },
+  "queryType": "SELECT",
+  "variables": [
+    "?title"
+  ],
+  "where": [
+    {
+      "type": "bgp",
+      "triples": [
+        {
+          "subject": "http://example.org/person/foo1/netWorth",
+          "predicate": "schema:value",
+          "object": "\"32\"^^http://www.w3.org/2001/XMLSchema#integer"
+        }
+      ]
+    }
+  ]
+}

--- a/test/unusedPrefixes/unused-prefixes-2.sparql
+++ b/test/unusedPrefixes/unused-prefixes-2.sparql
@@ -1,0 +1,1 @@
+SELECT ?title WHERE { <http://example.org/person/foo1/netWorth> <schema:value> 32 . }


### PR DESCRIPTION
Closes #24.