### PR TITLE
Support inherited prefixes when generating IRIs

### DIFF
--- a/lib/SparqlGenerator.js
+++ b/lib/SparqlGenerator.js
@@ -5,14 +5,15 @@ function Generator(options, prefixes) {
 
   prefixes = prefixes || {};
   this._prefixByIri = {};
-  var iriList = Object.keys(prefixes)
-                      .map(function (prefix) {
-                         var iri = prefixes[prefix];
-                         this._prefixByIri[iri] = prefix;
-                         return iri;
-                       }, this)
-                      .join('|')
-                      .replace(/[\]\/\(\)\*\+\?\.\\\$]/g, '\\$&');
+  var prefixIris = [];
+  for (var prefix in prefixes) {
+    var iri = prefixes[prefix];
+    if (typeof iri === 'string') {
+      this._prefixByIri[iri] = prefix;
+      prefixIris.push(iri);
+    }
+  }
+  var iriList = prefixIris.join('|').replace(/[\]\/\(\)\*\+\?\.\\\$]/g, '\\$&');
   this._prefixRegex = new RegExp('^(' + iriList + ')([a-zA-Z][\\-_a-zA-Z0-9]*)$');
   this._usedPrefixes = {};
 }

--- a/test/SparqlGenerator-test.js
+++ b/test/SparqlGenerator-test.js
@@ -43,4 +43,14 @@ describe('A SPARQL generator', function () {
       expect(generatedQuery + '\n').to.be.equal(expectedQuery);
     });
   });
+
+  it('should use inherited prefixes', function () {
+    var parser = new SparqlParser({rdfs: 'http://www.w3.org/2000/01/rdf-schema#'});
+    var parsedQuery = parser.parse('SELECT * WHERE { ?s rdfs:label ?o }');
+    var generatedQuery = defaultGenerator.stringify(parsedQuery);
+    var expectedQuery =
+      'PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>\n' +
+      'SELECT * WHERE { ?s rdfs:label ?o. }';
+    expect(generatedQuery).to.be.equal(expectedQuery);
+  });
 });


### PR DESCRIPTION
This PR adds support for inherited prefixes in a prefixes map for SPARQL generator.