### PR TITLE
Fix lost UNION sub-groups when collapseGroups is false

### DIFF
--- a/lib/sparql.jison
+++ b/lib/sparql.jison
@@ -617,7 +617,8 @@ GraphPatternNotTriples
     : ( GroupGraphPattern 'UNION' )* GroupGraphPattern
     {
       if (!Parser.options.collapseGroups)
-        $$ = !$1.length ? $2 : { type: 'union', patterns: unionAll($1, $2) };
+        $$ = !$1.length ? $2 :
+             { type: 'union', patterns: unionAll($1.map(degroupSingle), [degroupSingle($2)]) };
       else
         $$ = !$1.length ? degroupSingle($2) :
              { type: 'union', patterns: unionAll($1.map(degroupSingle), [degroupSingle($2)]) };

--- a/test/SparqlParser-test.js
+++ b/test/SparqlParser-test.js
@@ -127,5 +127,18 @@ describe('A SPARQL parser', function () {
         { type: 'bgp', triples: [{subject: '?a', predicate: '?b', object: '?c'}] },
       ]);
     });
+
+    it('should still collapse immediate union groups', function () {
+      var query = 'SELECT * WHERE { { ?s ?p ?o } UNION { ?a ?b ?c } }';
+      expect(parser.parse(query).where).to.deep.equal([
+        {
+          type: 'union',
+          patterns: [
+            { type: 'bgp', triples: [{subject: '?s', predicate: '?p', object: '?o'}] },
+            { type: 'bgp', triples: [{subject: '?a', predicate: '?b', object: '?c'}] },
+          ]
+        },
+      ]);
+    });
   });
 });


### PR DESCRIPTION
This is a fix for an error, introduced in b259983.

Maybe it makes sense to replace this block with
```
if ($1.length) {
  $$ = { type: 'union', patterns: unionAll($1.map(degroupSingle), [degroupSingle($2)]) };
} else {
  $$ = Parser.options.collapseGroups ? degroupSingle($2) : $2;
}
```
to make it easier to follow the logic here?