### PR TITLE
WIP: Improve query stringification

### DIFF
--- a/lib/SparqlGenerator.js
+++ b/lib/SparqlGenerator.js
@@ -90,16 +90,63 @@ Generator.prototype.toPattern = function (pattern) {
   return this[type](pattern);
 }
 
-Generator.prototype.triple = function (t) {
-  return this.toEntity(t.subject) + ' ' + this.toEntity(t.predicate) + ' ' + this.toEntity(t.object) + '.';
+Generator.prototype.tripleAfterPeriod = function(t) {
+  return this.toEntity(t.subject) + ' ' + this.tripleAfterSemicolon(t);
+};
+
+Generator.prototype.tripleAfterSemicolon = function(t) {
+  return this.toEntity(t.predicate) + ' ' + this.tripleAfterComma(t);
+};
+
+Generator.prototype.tripleAfterComma = function(t) {
+  return this.toEntity(t.object);
 };
 
 Generator.prototype.array = function (items) {
   return mapJoin(items, '\n', this.toPattern, this);
 };
 
+Generator.prototype.groupTriplesBy = function(triples, field) {
+  var groups = [];
+  var currentGroup = null;
+  for (var triple of triples) {
+    if (currentGroup === null) {
+      currentGroup = [triple];
+    } else {
+      if (currentGroup[0][field] === triple[field]) {
+        currentGroup.push(triple);
+      } else {
+        groups.push(currentGroup);
+        currentGroup = [triple];
+      }
+    }
+  }
+  if (currentGroup != null) {
+    groups.push(currentGroup);
+  }
+  return groups;
+};
+
+Generator.prototype.spaces = function(length) {
+  return Array(length + 1).join(' ');
+}
+
 Generator.prototype.bgp = function (bgp) {
-  return mapJoin(bgp.triples, '\n', this.triple, this);
+  var groups = this.groupTriplesBy(bgp.triples, 'subject');
+  var ret = '';
+  for (var group of groups) {
+	ret += '\n' + this.tripleAfterPeriod(group[0]);
+	for (var subgroup of this.groupTriplesBy(group.slice(1), 'predicate')) {
+	  ret += ';\n';
+	  ret += this.spaces(this.toEntity(group[0].subject).length + ' '.length);
+	  ret += this.tripleAfterSemicolon(subgroup[0]);
+	  for (var triple of subgroup.slice(1)) {
+		ret += ', ' + this.tripleAfterComma(triple);
+	  }
+	}
+	ret += '.';
+  }
+  return ret.substr(1); // strip off first \n
 };
 
 Generator.prototype.graph = function (graph) {


### PR DESCRIPTION
Abbreviate subsequent triples with the same subject with `;`, and subsequent triples with the same subject and predicate with `,`.

Yes, the tests don’t pass.

---

This is nowhere *near* ready for merging yet, I just wanted to upload what I have so there’s no duplicate work when someone else also wants to start working on #44.