### PR TITLE
Remove invalid hidden character

### DIFF
--- a/sparql.js
+++ b/sparql.js
@@ -17,7 +17,7 @@ module.exports = {
     // (Workaround for https://github.com/zaach/jison/issues/241)
     var parser = new Parser();
     parser.parse = function () {
-      Parser.base = baseIRI || '';
+      Parser.base = baseIRI || '';
       Parser.prefixes = Object.create(prefixesCopy);
       return Parser.prototype.parse.apply(parser, arguments);
     };


### PR DESCRIPTION
sparql.js contains a hidden character.
Node.js seems to be able to handle it, but when packaged using webpack, Chrome errors on it.
This commit fixes that by removing the hidden character.