### PR TITLE
Support GROUP BY variables when generating SPARQL

### DIFF
--- a/lib/SparqlGenerator.js
+++ b/lib/SparqlGenerator.js
@@ -48,7 +48,8 @@ Generator.prototype.toQuery = function (q) {
 
   if (q.group)
     query += 'GROUP BY ' + mapJoin(q.group, undefined, function (it) {
-      return isString(it.expression) ? it.expression : '(' + this.toExpression(it.expression) + ')';
+      var result = isString(it.expression) ? it.expression : '(' + this.toExpression(it.expression) + ')';
+      return it.variable ? '(' + result + ' AS ' + it.variable + ')' : result;
     }, this) + '\n';
   if (q.having)
     query += 'HAVING (' + mapJoin(q.having, undefined, this.toExpression, this) + ')\n';

--- a/queries/group_variable.sparql
+++ b/queries/group_variable.sparql
@@ -1,0 +1,4 @@
+PREFIX : <http://www.example.org/>
+SELECT ?O12 (COUNT(?O1) AS ?C)
+WHERE { ?S :p ?O1; :q ?O2 } GROUP BY ((?O1 + ?O2) AS ?O12)
+ORDER BY ?O12

--- a/test/parsedQueries/group_variable.json
+++ b/test/parsedQueries/group_variable.json
@@ -1,0 +1,54 @@
+{
+  "queryType": "SELECT",
+  "variables": [
+    "?O12",
+    {
+      "expression": {
+        "expression": "?O1",
+        "type": "aggregate",
+        "aggregation": "count",
+        "distinct": false
+      },
+      "variable": "?C"
+    }
+  ],
+  "where": [
+    {
+      "type": "bgp",
+      "triples": [
+        {
+          "subject": "?S",
+          "predicate": "http://www.example.org/p",
+          "object": "?O1"
+        },
+        {
+          "subject": "?S",
+          "predicate": "http://www.example.org/q",
+          "object": "?O2"
+        }
+      ]
+    }
+  ],
+  "group": [
+    {
+      "expression": {
+        "type": "operation",
+        "operator": "+",
+        "args": [
+          "?O1",
+          "?O2"
+        ]
+      },
+      "variable": "?O12"
+    }
+  ],
+  "order": [
+    {
+      "expression": "?O12"
+    }
+  ],
+  "type": "query",
+  "prefixes": {
+    "": "http://www.example.org/"
+  }
+}


### PR DESCRIPTION
Currently the variable in a GROUP BY element is ignored when generating the corresponding SPARQL string.