### PR TITLE
Place brackets around order expressions

### DIFF
--- a/lib/SparqlGenerator.js
+++ b/lib/SparqlGenerator.js
@@ -55,8 +55,8 @@ Generator.prototype.toQuery = function (q) {
     query += 'HAVING (' + mapJoin(q.having, undefined, this.toExpression, this) + ')\n';
   if (q.order)
     query += 'ORDER BY ' + mapJoin(q.order, undefined, function (it) {
-      var expr = this.toExpression(it.expression);
-      return !it.descending ? expr : 'DESC(' + expr + ')';
+      var expr = '(' + this.toExpression(it.expression) + ')';
+      return !it.descending ? expr : 'DESC ' + expr;
     }, this) + '\n';
 
   if (q.offset)

--- a/queries/order-operator.sparql
+++ b/queries/order-operator.sparql
@@ -1,0 +1,3 @@
+PREFIX : <http://example.org/ns#>
+SELECT * { ?s ?p ?o }
+ORDER BY (?o+5)

--- a/test/parsedQueries/order-operator.json
+++ b/test/parsedQueries/order-operator.json
@@ -1,0 +1,34 @@
+{
+  "queryType": "SELECT",
+  "variables": [
+    "*"
+  ],
+  "where": [
+    {
+      "type": "bgp",
+      "triples": [
+        {
+          "subject": "?s",
+          "predicate": "?p",
+          "object": "?o"
+        }
+      ]
+    }
+  ],
+  "order": [
+    {
+      "expression": {
+        "type": "operation",
+        "operator": "+",
+        "args": [
+          "?o",
+          "\"5\"^^http://www.w3.org/2001/XMLSchema#integer"
+        ]
+      }
+    }
+  ],
+  "type": "query",
+  "prefixes": {
+    "": "http://example.org/ns#"
+  }
+}


### PR DESCRIPTION
Currently, the generator would generate the following query:
```sparql
PREFIX : <http://example.org/ns#>
SELECT * { ?s ?p ?o }
ORDER BY ?o+5
```
Which is invalid and can't be parsed again by the parser due to the missing brackets around `?o+5`.

Although it is not necessary to place brackets around all expressions, it is also not wrong. So this felt like the more cleaner solution for me instead of adding exceptions for specific cases.