### PR TITLE
Place parentheses for path postfix operators

### DIFF
--- a/lib/SparqlGenerator.js
+++ b/lib/SparqlGenerator.js
@@ -251,7 +251,7 @@ Generator.prototype.toEntity = function (value) {
     case '*':
     case '+':
     case '?':
-      return items[0] + path;
+      return '(' + items[0] + path + ')';
     // infix operator
     default:
       return '(' + items.join(path) + ')';

--- a/queries/nested-path.sparql
+++ b/queries/nested-path.sparql
@@ -1,0 +1,3 @@
+prefix : <http://example.org/>
+select ?X where { :A0 ((:P)*)* ?X }
+order by ?X

--- a/test/parsedQueries/nested-path.json
+++ b/test/parsedQueries/nested-path.json
@@ -1,0 +1,39 @@
+{
+  "queryType": "SELECT",
+  "variables": [
+    "?X"
+  ],
+  "where": [
+    {
+      "type": "bgp",
+      "triples": [
+        {
+          "subject": "http://example.org/A0",
+          "predicate": {
+            "type": "path",
+            "pathType": "*",
+            "items": [
+              {
+                "type": "path",
+                "pathType": "*",
+                "items": [
+                  "http://example.org/P"
+                ]
+              }
+            ]
+          },
+          "object": "?X"
+        }
+      ]
+    }
+  ],
+  "order": [
+    {
+      "expression": "?X"
+    }
+  ],
+  "type": "query",
+  "prefixes": {
+    "": "http://example.org/"
+  }
+}


### PR DESCRIPTION
This is to prevent problems when having nested path operators.

```sparql
prefix : <http://example.org/>
select ?X where { :A0 ((:P)*)* ?X }
order by ?X
```
When parsing this query and converting it back to sparql the result was the following:
```
prefix : <http://example.org/>
select ?X where { :A0 :P** ?X }
order by ?X
```
Which is invalid due to the double path operators.