### PR TITLE
remove irregular white spaces

### DIFF
--- a/lib/sparql.jison
+++ b/lib/sparql.jison
@@ -427,7 +427,7 @@ PN_LOCAL_ESC          "\\"("_"|"~"|"."|"-"|"!"|"$"|"&"|"'"|"("|")"|"*"|"+"|","|"
 QueryOrUpdate
     : Prologue ( Query | Update? ) EOF
     {
-      $2 = $2 || {};
+      $2 = $2 || {};
       if (Parser.base)
         $2.base = Parser.base;
       Parser.base = base = basePath = baseRoot = '';

--- a/test/test-setup.js
+++ b/test/test-setup.js
@@ -1,4 +1,4 @@
-// Parses a JSON object, restoring `undefined` values
+// Parses a JSON object, restoring `undefined` values
 global.parseJSON = function parseJSON(string) {
   var object = JSON.parse(string);
   return /"\{undefined\}"/.test(string) ? restoreUndefined(object) : object;


### PR DESCRIPTION
When using browserify on a module that requires SPARQL.js I get errors because of irregular whitespaces being transformed incorrectly. I know that this is actually an issue with browserify, but thought that it would be useful also to clean up the white spaces here anyway - as they can cause other issues too.

Perhaps its worth adding eslint to this library with the no-irregular-whitespace rule.

Also - thanks for making an awesome sparql parser!