### PR TITLE
Allow for a semi-colon before the final period in CONSTRUCT queries

### DIFF
--- a/lib/sparql.jison
+++ b/lib/sparql.jison
@@ -654,7 +654,7 @@ PropertyList
     : PropertyListNotEmpty?
     ;
 PropertyListNotEmpty
-    : ( VerbObjectList ';'+ )* VerbObjectList -> unionAll($1, [$2])
+    : ( VerbObjectList ';'+ )* VerbObjectList ';'? -> unionAll($1, [$2])
     ;
 VerbObjectList
     : Verb ObjectList -> objectListToTriples($1, $2)

--- a/lib/sparql.jison
+++ b/lib/sparql.jison
@@ -654,7 +654,10 @@ PropertyList
     : PropertyListNotEmpty?
     ;
 PropertyListNotEmpty
-    : ( VerbObjectList ';'+ )* VerbObjectList ';'? -> unionAll($1, [$2])
+    : VerbObjectList ( SemiOptionalVerbObjectList )* -> $2 ? unionAll([$1], $2) : unionAll([$1])
+    ;
+SemiOptionalVerbObjectList
+    : ';' VerbObjectList? -> unionAll($2)
     ;
 VerbObjectList
     : Verb ObjectList -> objectListToTriples($1, $2)

--- a/lib/sparql.jison
+++ b/lib/sparql.jison
@@ -654,7 +654,7 @@ PropertyList
     : PropertyListNotEmpty?
     ;
 PropertyListNotEmpty
-    : VerbObjectList ( SemiOptionalVerbObjectList )* -> $2 ? unionAll([$1], $2) : unionAll([$1])
+    : VerbObjectList ( SemiOptionalVerbObjectList )* -> unionAll([$1], $2)
     ;
 SemiOptionalVerbObjectList
     : ';' VerbObjectList? -> unionAll($2)

--- a/queries/construct-extra-semicolon.sparql
+++ b/queries/construct-extra-semicolon.sparql
@@ -1,1 +1,6 @@
-CONSTRUCT { ?s a <http://example.org/ExampleThing>; ?p ?o; . } WHERE { ?s ?p ?o }
+CONSTRUCT { 
+  ?s a <http://example.org/ExampleThing>;
+     <http://example.org/hasvalue> "value";
+     ?p ?o;
+  .
+} WHERE { ?s ?p ?o }

--- a/queries/construct-extra-semicolon.sparql
+++ b/queries/construct-extra-semicolon.sparql
@@ -1,0 +1,1 @@
+CONSTRUCT { ?s a <http://example.org/ExampleThing>; ?p ?o; . } WHERE { ?s ?p ?o }

--- a/queries/construct-multi-extra-semicolons.sparql
+++ b/queries/construct-multi-extra-semicolons.sparql
@@ -1,6 +1,6 @@
 CONSTRUCT { 
-  ?s a <http://example.org/ExampleThing>;
-     <http://example.org/hasvalue> "value";
+  ?s a <http://example.org/ExampleThing>;;
+     <http://example.org/hasvalue> "value";;
      ?p ?o;;;
   .
 } WHERE { ?s ?p ?o }

--- a/queries/construct-multi-extra-semicolons.sparql
+++ b/queries/construct-multi-extra-semicolons.sparql
@@ -1,0 +1,6 @@
+CONSTRUCT { 
+  ?s a <http://example.org/ExampleThing>;
+     <http://example.org/hasvalue> "value";
+     ?p ?o;;;
+  .
+} WHERE { ?s ?p ?o }

--- a/test/parsedQueries/construct-extra-semicolon.json
+++ b/test/parsedQueries/construct-extra-semicolon.json
@@ -1,0 +1,29 @@
+{
+  "type": "query",
+  "prefixes": {},
+  "queryType": "CONSTRUCT",
+  "template": [
+    {
+      "subject": "?s",
+      "predicate": "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
+      "object": "http://example.org/ExampleThing"
+    },
+    {
+      "subject": "?s",
+      "predicate": "?p",
+      "object": "?o"
+    }
+  ],
+  "where": [
+    {
+      "type": "bgp",
+      "triples": [
+        {
+          "subject": "?s",
+          "predicate": "?p",
+          "object": "?o"
+        }
+      ]
+    }
+  ]
+}

--- a/test/parsedQueries/construct-extra-semicolon.json
+++ b/test/parsedQueries/construct-extra-semicolon.json
@@ -10,6 +10,11 @@
     },
     {
       "subject": "?s",
+      "predicate": "http://example.org/hasvalue",
+      "object": "\"value\""
+    },
+    {
+      "subject": "?s",
       "predicate": "?p",
       "object": "?o"
     }

--- a/test/parsedQueries/construct-multi-extra-semicolons.json
+++ b/test/parsedQueries/construct-multi-extra-semicolons.json
@@ -1,0 +1,34 @@
+{
+  "type": "query",
+  "prefixes": {},
+  "queryType": "CONSTRUCT",
+  "template": [
+    {
+      "subject": "?s",
+      "predicate": "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
+      "object": "http://example.org/ExampleThing"
+    },
+    {
+      "subject": "?s",
+      "predicate": "http://example.org/hasvalue",
+      "object": "\"value\""
+    },
+    {
+      "subject": "?s",
+      "predicate": "?p",
+      "object": "?o"
+    }
+  ],
+  "where": [
+    {
+      "type": "bgp",
+      "triples": [
+        {
+          "subject": "?s",
+          "predicate": "?p",
+          "object": "?o"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
To match the spec...

See: https://www.w3.org/TR/sparql11-query/#rPropertyListNotEmpty

This indicates that the following _should_ be legal...

```
CONSTRUCT {
  ?s ?p ?o; 
     a <http://example.org/Thing>; 
  .
} WHERE {
  ?s ?p ?o
}
```
But it doesn't currently parse correctly. We see this pattern fairly frequently in our app. This is valid in Turtle, so people assume it's valid in `CONSTRUCT` queries as well.

NOTE: This is my first attempt at working with a JISON grammar like this, so please tell me if there's a better way to accomplish what I'm trying to (or if this doesn't make sense).