### PR TITLE
Stringify single-variable VALUES without parens

### DIFF
--- a/lib/SparqlGenerator.js
+++ b/lib/SparqlGenerator.js
@@ -177,12 +177,20 @@ Generator.prototype.values = function (valuesList) {
     for (var key in values) keyHash[key] = true;
     return keyHash;
   }, {}));
+  // Check whether simple syntax can be used
+  var lparen, rparen;
+  if (keys.length === 1) {
+    lparen = rparen = '';
+  } else {
+    lparen = '(';
+    rparen = ')';
+  }
   // Create value rows
-  return 'VALUES (' + keys.join(' ') + ') {\n' +
+  return 'VALUES ' + lparen + keys.join(' ') + rparen + ' {\n' +
     mapJoin(valuesList.values, '\n', function (values) {
-      return '  (' + mapJoin(keys, undefined, function (key) {
+      return '  ' + lparen + mapJoin(keys, undefined, function (key) {
         return values[key] !== undefined ? this.toEntity(values[key]) : 'UNDEF';
-      }, this) + ')';
+      }, this) + rparen;
     }, this) + '\n}';
 };
 


### PR DESCRIPTION
SPARQL has a special syntax for the common case of `VALUES` clauses with only one variable, where the parentheses may be omitted. Produce such clauses in `SparqlGenerator` when possible.

Partially fixes #68 (does not address line folding).

---

This doesn’t add any tests yet, because I’m not sure how they should be done. The existing tests for `SparqlGenerator` don’t directly compare the original and generated query string: they parse both and then assert that they’re equal. Such a comparison is not affected by this change – a test for this would check that we don’t generate invalid `VALUES` clauses, but not ensure that we don’t stop generating the single-variable version in the future.

I could add a very specific test for this feature to `SparqlGenerator-test.js` (or a new test file), but most of the existing tests are parameterized and work on a list of queries. So perhaps it would be better to add another test which compares the generated SPARQL to a certain file (say, `test/generatedQueries/QUERY.sparql`) if it exists?