### PR TITLE
Encapsulate negation contents

### DIFF
--- a/lib/SparqlGenerator.js
+++ b/lib/SparqlGenerator.js
@@ -232,7 +232,7 @@ Generator.prototype.toExpression = function (expr) {
                  (isString(args[1]) ? this.toEntity(args[1]) : '(' + this.toExpression(args[1]) + ')');
       // Unary operators
       case '!':
-        return '!' + this.toExpression(args[0]);
+        return '!(' + this.toExpression(args[0]) + ')';
       // IN and NOT IN
       case 'notin':
         operator = 'NOT IN';

--- a/queries/negate-and.sparql
+++ b/queries/negate-and.sparql
@@ -1,0 +1,8 @@
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+
+select *
+where {
+    { ?c a owl:Class . }
+    FILTER ( ! (BOUND(?c) && ( REGEX(str(?c), "^toto","i"))) )
+}
+limit 10

--- a/test/parsedQueries/negate-and.json
+++ b/test/parsedQueries/negate-and.json
@@ -1,0 +1,65 @@
+{
+  "queryType": "SELECT",
+  "variables": [
+    "*"
+  ],
+  "where": [
+    {
+      "type": "group",
+      "patterns": [
+        {
+          "type": "bgp",
+          "triples": [
+            {
+              "subject": "?c",
+              "predicate": "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
+              "object": "http://www.w3.org/2002/07/owl#Class"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "filter",
+      "expression": {
+        "type": "operation",
+        "operator": "!",
+        "args": [
+          {
+            "type": "operation",
+            "operator": "&&",
+            "args": [
+              {
+                "type": "operation",
+                "operator": "bound",
+                "args": [
+                  "?c"
+                ]
+              },
+              {
+                "type": "operation",
+                "operator": "regex",
+                "args": [
+                  {
+                    "type": "operation",
+                    "operator": "str",
+                    "args": [
+                      "?c"
+                    ]
+                  },
+                  "\"^toto\"",
+                  "\"i\""
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    }
+  ],
+  "limit": 10,
+  "type": "query",
+  "prefixes": {
+    "owl": "http://www.w3.org/2002/07/owl#"
+  }
+}


### PR DESCRIPTION
Previously in the example query, after parsing and sparql re-generation it returned the following filter part (notice the missing brackets around the `&&` block):
```sparql
FILTER( ! (BOUND(?c)) && ( REGEX(STR(?c), "^toto", "i")))
```