### PR TITLE
Run SPARQL test suite on Travis builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 *.log
 lib/SparqlParser.js
+.rdf-test-suite-cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,10 @@ node_js:
 before_script:
   - npm run build
 
-cache: npm
+script:
+  - npm test
+  - npm run spec
+cache:
+ - npm
+ - directories:
+   - .rdf-test-suite-cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
- - "6"
  - "8"
  - "10"
  - "12"

--- a/package-lock.json
+++ b/package-lock.json
@@ -68,6 +68,15 @@
         "@types/yargs": "^12.0.9"
       }
     },
+    "@rdfjs/data-model": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@rdfjs/data-model/-/data-model-1.1.2.tgz",
+      "integrity": "sha512-pk/G/JLYGaXesoBLvEmoC/ic0H3B79fTyS0Ujjh5YQB2DZW+mn05ZowFFv88rjB9jf7c1XE5XSmf8jzn6U0HHA==",
+      "dev": true,
+      "requires": {
+        "@types/rdf-js": "^2.0.1"
+      }
+    },
     "@types/istanbul-lib-coverage": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz",
@@ -93,6 +102,21 @@
         "@types/istanbul-lib-report": "*"
       }
     },
+    "@types/node": {
+      "version": "12.7.9",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.9.tgz",
+      "integrity": "sha512-P57oKTJ/vYivL2BCfxCC5tQjlS8qW31pbOL6qt99Yrjm95YdHgNZwjrTTjMBh+C2/y6PXIX4oz253+jUzxKKfQ==",
+      "dev": true
+    },
+    "@types/rdf-js": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@types/rdf-js/-/rdf-js-2.0.2.tgz",
+      "integrity": "sha512-rHtC0mtRmMc9JzITesWhzmAXqfyJZhY8MygmmWZc3oWS5DPsGsKs+t3RXxGYlM4UKOqlD9Ki4owS1Cx/GPMeqw==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/stack-utils": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-1.0.1.tgz",
@@ -110,6 +134,16 @@
       "resolved": "https://registry.npmjs.org/JSONSelect/-/JSONSelect-0.4.0.tgz",
       "integrity": "sha1-oI7cxn6z/L6Z7WMIVTRKDPKCu40=",
       "dev": true
+    },
+    "JSONStream": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
+      "integrity": "sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==",
+      "dev": true,
+      "requires": {
+        "jsonparse": "^1.2.0",
+        "through": ">=2.2.7 <3"
+      }
     },
     "JSV": {
       "version": "4.0.2",
@@ -161,6 +195,12 @@
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
       "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+      "dev": true
+    },
+    "arrayify-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/arrayify-stream/-/arrayify-stream-1.0.0.tgz",
+      "integrity": "sha512-RP80ep76Lbew2wWN5ogrl2NluTnBVYYh2K3NNCcWfcmmUB7nBcNBctiJeEZAixp3I1vQ9H88iHZ9MbHSdkuupQ==",
       "dev": true
     },
     "assign-symbols": {
@@ -511,6 +551,15 @@
       "integrity": "sha1-zR9rpHfFY4xAyX7ZtXLbW6tdgzE=",
       "dev": true
     },
+    "encoding": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+      "dev": true,
+      "requires": {
+        "iconv-lite": "~0.4.13"
+      }
+    },
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
@@ -820,6 +869,15 @@
       "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
       "dev": true
     },
+    "iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "dev": true,
+      "requires": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      }
+    },
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -936,6 +994,12 @@
         "isobject": "^3.0.1"
       }
     },
+    "is-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+      "dev": true
+    },
     "is-windows": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
@@ -959,6 +1023,16 @@
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
       "dev": true
+    },
+    "isomorphic-fetch": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
+      "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
+      "dev": true,
+      "requires": {
+        "node-fetch": "^1.0.1",
+        "whatwg-fetch": ">=0.10.0"
+      }
     },
     "jest-diff": {
       "version": "24.8.0",
@@ -1044,6 +1118,43 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "dev": true
     },
+    "json-stable-stringify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+      "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+      "dev": true,
+      "requires": {
+        "jsonify": "~0.0.0"
+      }
+    },
+    "jsonify": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
+      "dev": true
+    },
+    "jsonld-context-parser": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/jsonld-context-parser/-/jsonld-context-parser-1.3.2.tgz",
+      "integrity": "sha512-jc2ZBJ6yRjDKvWcWcYc8NWBUoslpSEfL1HfG4+NzHdIz/gm0biMzbuV90k6ypcoEVrjC6F9l1mItT5cx7+nuqA==",
+      "dev": true,
+      "requires": {
+        "isomorphic-fetch": "^2.2.1",
+        "relative-to-absolute-iri": "^1.0.2"
+      }
+    },
+    "jsonld-streaming-parser": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/jsonld-streaming-parser/-/jsonld-streaming-parser-1.1.1.tgz",
+      "integrity": "sha512-/C+h4zxQnVFVO4FIPTqxzOjRT5Vd2wcX+y5MZ1oA3xv3xs0+GrywC/STyml8d4mOLJI7sSAvYyJ86439fNgt9g==",
+      "dev": true,
+      "requires": {
+        "@rdfjs/data-model": "^1.1.1",
+        "@types/rdf-js": "^2.0.1",
+        "jsonld-context-parser": "^1.3.2",
+        "jsonparse": "^1.3.1"
+      }
+    },
     "jsonlint": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/jsonlint/-/jsonlint-1.6.0.tgz",
@@ -1053,6 +1164,12 @@
         "JSV": ">= 4.0.x",
         "nomnom": ">= 1.5.x"
       }
+    },
+    "jsonparse": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
+      "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
+      "dev": true
     },
     "kind-of": {
       "version": "6.0.2",
@@ -1065,6 +1182,21 @@
       "resolved": "https://registry.npmjs.org/lex-parser/-/lex-parser-0.1.4.tgz",
       "integrity": "sha1-ZMTwJfF/1Tv7RXY/rrFvAVp0dVA=",
       "dev": true
+    },
+    "lodash.uniqwith": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.uniqwith/-/lodash.uniqwith-4.5.0.tgz",
+      "integrity": "sha1-egy/ZfQ7WShiWp1NDcVLGMrcfvM=",
+      "dev": true
+    },
+    "log-symbols": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-3.0.0.tgz",
+      "integrity": "sha512-dSkNGuI7iG3mfvDzUuYZyvk5dD9ocYCYzNU6CYDE6+Xqd+gwme6Z00NS3dUh8mq/73HaEtT7m6W+yUPtU6BZnQ==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.4.2"
+      }
     },
     "lru-cache": {
       "version": "4.1.5",
@@ -1231,6 +1363,26 @@
         "to-regex": "^3.0.1"
       }
     },
+    "node-fetch": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+      "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+      "dev": true,
+      "requires": {
+        "encoding": "^0.1.11",
+        "is-stream": "^1.0.1"
+      }
+    },
+    "node-web-streams": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/node-web-streams/-/node-web-streams-0.2.2.tgz",
+      "integrity": "sha1-CH52u+t+jcVmhrJdtOYMX/nbCR8=",
+      "dev": true,
+      "requires": {
+        "is-stream": "^1.1.0",
+        "web-streams-polyfill": "git://github.com/gwicke/web-streams-polyfill.git#42c488428adea1dc0c0245014e4896ad456b1ded"
+      }
+    },
     "nomnom": {
       "version": "1.5.2",
       "resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.5.2.tgz",
@@ -1352,11 +1504,127 @@
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "dev": true
     },
+    "promise-polyfill": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-1.1.6.tgz",
+      "integrity": "sha1-zQTv9G9clcOn0EVZHXm14+AfEtc=",
+      "dev": true
+    },
     "pseudomap": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
       "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
       "dev": true
+    },
+    "rdf-isomorphic": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/rdf-isomorphic/-/rdf-isomorphic-1.1.0.tgz",
+      "integrity": "sha512-E4E3RJJ0RBBCDGJ6cx7httfnV0Z2xcdF81epe581xSvPsCe42qWYysZ6DKTkBTrmMjNeScNnDkjubLS5RSODtw==",
+      "dev": true,
+      "requires": {
+        "rdf-string": "^1.3.1",
+        "rdf-terms": "^1.4.0"
+      }
+    },
+    "rdf-literal": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/rdf-literal/-/rdf-literal-1.0.0.tgz",
+      "integrity": "sha512-PlNYjvacRKmixW89t8oviIVL1zIevNK/1ty5ZHhgyWfP1pBewzLG4euNv3Uqi2us8QAcuwjfD8aeSXFrdiYLlw==",
+      "dev": true,
+      "requires": {
+        "@rdfjs/data-model": "^1.1.1",
+        "@types/rdf-js": "^2.0.2"
+      }
+    },
+    "rdf-object": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/rdf-object/-/rdf-object-1.1.1.tgz",
+      "integrity": "sha512-60YdkQ4rgetCEcDu4XqRiTuSIJwJw0Dok48FhSU0t9dCfsHMuOuethbdNqFhVNmjFlB6bD58zc+ibmV+g2o24A==",
+      "dev": true,
+      "requires": {
+        "@rdfjs/data-model": "^1.1.1",
+        "jsonld-context-parser": "^1.1.0",
+        "rdf-string": "^1.3.1",
+        "streamify-array": "^1.0.1"
+      }
+    },
+    "rdf-quad": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/rdf-quad/-/rdf-quad-1.4.0.tgz",
+      "integrity": "sha512-xChDvhK2zb4/aCg8P668CWTn4TEhscefg/E1s+Qu61sZ/hKct/WQn0wuHim8H+MFrzZ7fFN7Gh7aamPgm/QSwA==",
+      "dev": true,
+      "requires": {
+        "@rdfjs/data-model": "^1.1.1",
+        "rdf-literal": "^1.0.0",
+        "rdf-string": "^1.3.1"
+      }
+    },
+    "rdf-string": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/rdf-string/-/rdf-string-1.3.1.tgz",
+      "integrity": "sha512-Pcw6aZRfto2cZodK5kSqFZW8mz6nfKLxSfjOSrTi5ajb2CSIwzqGx7UniysgKoV2i7tQL5dpPgCgY80upCiRUw==",
+      "dev": true,
+      "requires": {
+        "@rdfjs/data-model": "^1.1.1"
+      }
+    },
+    "rdf-terms": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/rdf-terms/-/rdf-terms-1.5.1.tgz",
+      "integrity": "sha512-dDhpUYxTAOWKT3Ln93A5k5UB5SftG8bPAzeZEjGeP4e7eboMhITUTDks8HDmUt9X1P+HpfnY/o6VSTSpf3Advw==",
+      "dev": true,
+      "requires": {
+        "@rdfjs/data-model": "^1.1.1",
+        "lodash.uniqwith": "^4.5.0"
+      }
+    },
+    "rdf-test-suite": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/rdf-test-suite/-/rdf-test-suite-1.11.0.tgz",
+      "integrity": "sha512-qEmvKInf8s52o7WZfL7u5UQjmti3rsWvhJ0jn5iJ86CHGGDcsm1ye++eNM3cVAnpoaYiLtPBWZOoTsdEBd12Vg==",
+      "dev": true,
+      "requires": {
+        "@rdfjs/data-model": "^1.1.1",
+        "arrayify-stream": "^1.0.0",
+        "isomorphic-fetch": "^2.2.1",
+        "json-stable-stringify": "^1.0.1",
+        "jsonld-streaming-parser": "^1.1.1",
+        "log-symbols": "^3.0.0",
+        "minimist": "^1.2.0",
+        "n3": "^1.1.1",
+        "node-web-streams": "^0.2.2",
+        "rdf-isomorphic": "^1.1.0",
+        "rdf-literal": "^1.0.0",
+        "rdf-object": "^1.1.0",
+        "rdf-quad": "^1.3.0",
+        "rdf-string": "^1.3.1",
+        "rdf-terms": "^1.4.0",
+        "rdfxml-streaming-parser": "^1.1.0",
+        "relative-to-absolute-iri": "^1.0.5",
+        "sparqljson-parse": "^1.5.0",
+        "sparqlxml-parse": "^1.2.1",
+        "stream-to-string": "^1.1.0",
+        "streamify-string": "^1.0.1"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        }
+      }
+    },
+    "rdfxml-streaming-parser": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/rdfxml-streaming-parser/-/rdfxml-streaming-parser-1.3.1.tgz",
+      "integrity": "sha512-lQfkAmN1rmfaks/Ag9oOF9MdFhlb2jNzdzCisO0u4zaNqU318Y2sMV4nxIjXlqMXfHTZK/x+FEHRlqpaq0fxhQ==",
+      "dev": true,
+      "requires": {
+        "@rdfjs/data-model": "^1.1.1",
+        "relative-to-absolute-iri": "^1.0.0",
+        "sax": "^1.2.4"
+      }
     },
     "react-is": {
       "version": "16.8.6",
@@ -1388,6 +1656,12 @@
         "extend-shallow": "^3.0.2",
         "safe-regex": "^1.1.0"
       }
+    },
+    "relative-to-absolute-iri": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/relative-to-absolute-iri/-/relative-to-absolute-iri-1.0.5.tgz",
+      "integrity": "sha512-sHpUlpF3fRWtTcBa8uBIwQ+Z/YnjDjerocV3q0FrP8T9oZ3z6d61I12ZcGlGr9jW2cQbcCkErCT9XLcN18ZLaQ==",
+      "dev": true
     },
     "repeat-element": {
       "version": "1.1.3",
@@ -1426,6 +1700,28 @@
       "dev": true,
       "requires": {
         "ret": "~0.1.10"
+      }
+    },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true
+    },
+    "sax": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
+      "dev": true
+    },
+    "sax-stream": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/sax-stream/-/sax-stream-1.3.0.tgz",
+      "integrity": "sha512-tcfsAAICAkyNNe4uiKtKmLKxx3C7qPAej13UUoN+7OLYq/P5kHGahZtJhhMVM3fIMndA6TlYHWFlFEzFkv1VGg==",
+      "dev": true,
+      "requires": {
+        "debug": "~2",
+        "sax": "~1"
       }
     },
     "set-value": {
@@ -1610,6 +1906,46 @@
       "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
       "dev": true
     },
+    "sparqljson-parse": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/sparqljson-parse/-/sparqljson-parse-1.5.1.tgz",
+      "integrity": "sha512-+hlVthsoADK/gZkNrV6GCz7Ep3GwtY8DNJSjt9Mt32vuTL9QbQlCRalqOQRaz7D/oyRAsNvkW6/KldMA7s2YCQ==",
+      "dev": true,
+      "requires": {
+        "@rdfjs/data-model": "^1.1.1",
+        "@types/node": "^10.12.18",
+        "@types/rdf-js": "^2.0.2",
+        "JSONStream": "^1.3.3"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "10.14.19",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.19.tgz",
+          "integrity": "sha512-j6Sqt38ssdMKutXBUuAcmWF8QtHW1Fwz/mz4Y+Wd9mzpBiVFirjpNQf363hG5itkG+yGaD+oiLyb50HxJ36l9Q==",
+          "dev": true
+        }
+      }
+    },
+    "sparqlxml-parse": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/sparqlxml-parse/-/sparqlxml-parse-1.2.2.tgz",
+      "integrity": "sha512-xFN+S97DRI9jrlFsOntB8rmtEAJeTUAyRCquibiLCbE+z63iw1tFdM9NhrphrPey1+EH75vh9AjycXwDD6nEIw==",
+      "dev": true,
+      "requires": {
+        "@rdfjs/data-model": "^1.1.1",
+        "@types/node": "^10.12.18",
+        "@types/rdf-js": "^2.0.2",
+        "sax-stream": "^1.2.3"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "10.14.19",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.19.tgz",
+          "integrity": "sha512-j6Sqt38ssdMKutXBUuAcmWF8QtHW1Fwz/mz4Y+Wd9mzpBiVFirjpNQf363hG5itkG+yGaD+oiLyb50HxJ36l9Q==",
+          "dev": true
+        }
+      }
+    },
     "spawn-sync": {
       "version": "1.0.15",
       "resolved": "https://registry.npmjs.org/spawn-sync/-/spawn-sync-1.0.15.tgz",
@@ -1656,6 +1992,27 @@
         }
       }
     },
+    "stream-to-string": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/stream-to-string/-/stream-to-string-1.2.0.tgz",
+      "integrity": "sha512-8drZlFIKBHSMdX9GCWv8V9AAWnQcTqw0iAI6/GC7UJ0H0SwKeFKjOoZfGY1tOU00GGU7FYZQoJ/ZCUEoXhD7yQ==",
+      "dev": true,
+      "requires": {
+        "promise-polyfill": "^1.1.6"
+      }
+    },
+    "streamify-array": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/streamify-array/-/streamify-array-1.0.1.tgz",
+      "integrity": "sha512-ZnswaBcC6B1bhPLSQOlC6CdaDUSzU0wr2lvvHpbHNms8V7+DLd8uEAzDAWpsjxbFkijBHhuObFO/qqu52DZUMA==",
+      "dev": true
+    },
+    "streamify-string": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/streamify-string/-/streamify-string-1.0.1.tgz",
+      "integrity": "sha1-niIN4z4cR13TDgIG9bGBXMbJUls=",
+      "dev": true
+    },
     "string_decoder": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
@@ -1673,6 +2030,12 @@
       "requires": {
         "has-flag": "^3.0.0"
       }
+    },
+    "through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+      "dev": true
     },
     "to-object-path": {
       "version": "0.3.0",
@@ -1796,6 +2159,17 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
+    },
+    "web-streams-polyfill": {
+      "version": "git://github.com/gwicke/web-streams-polyfill.git#42c488428adea1dc0c0245014e4896ad456b1ded",
+      "from": "git://github.com/gwicke/web-streams-polyfill.git#spec_performance_improvements",
+      "dev": true
+    },
+    "whatwg-fetch": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz",
+      "integrity": "sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q==",
       "dev": true
     },
     "which": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,12 @@
   ],
   "scripts": {
     "build": "./node_modules/.bin/jison lib/sparql.jison -p slr -o lib/SparqlParser.js",
-    "test": "./node_modules/.bin/mocha"
+    "test": "./node_modules/.bin/mocha",
+    "spec-base-query": "rdf-test-suite spec/parser.js http://w3c.github.io/rdf-tests/sparql11/data-sparql11/manifest-all.ttl -s http://www.w3.org/TR/sparql11-query/ -c .rdf-test-suite-cache/",
+    "spec-base-update": "rdf-test-suite spec/parser.js http://w3c.github.io/rdf-tests/sparql11/data-sparql11/manifest-all.ttl -s http://www.w3.org/TR/sparql11-update/ -c .rdf-test-suite-cache/",
+    "spec-earl-query": "npm run spec-base-query --silent -- -o earl -p spec/earl-meta.json > spec/earl-query.ttl",
+    "spec-earl-update": "npm run spec-base-update --silent -- -o earl -p spec/earl-meta.json > spec/earl-update.ttl",
+    "spec": "npm run spec-base-query -- -e && npm run spec-base-update -- -e"
   },
   "engines": {
     "node": ">=8.0"
@@ -38,7 +43,8 @@
     "expect": "^24.8.0",
     "jison": "0.4.18",
     "mocha": "4.1.x",
-    "pre-commit": "~1.2.2"
+    "pre-commit": "~1.2.2",
+    "rdf-test-suite": "^1.11.0"
   },
   "browser": {
     "_process": false,

--- a/spec/earl-meta.json
+++ b/spec/earl-meta.json
@@ -1,0 +1,22 @@
+{
+  "applicationBugsUrl": "https://github.com/RubenVerborgh/SPARQL.js/issues",
+  "applicationDescription": "A parser for the SPARQL query language in JavaScript.",
+  "applicationNameFull": "sparqljs",
+  "applicationNameNpm": "sparqljs",
+  "applicationHomepageUrl": "https://github.com/RubenVerborgh/SPARQL.js",
+  "applicationBlogUrl": "https://ruben.verborgh.org/blog/",
+  "applicationUri": "https://www.npmjs.com/package/sparqljs/",
+  "authors": [
+    {
+      "homepage": "https://ruben.verborgh.org/",
+      "name": "Ruben Verborgh <ruben.verborgh@gmail.com>",
+      "uri": "https://ruben.verborgh.org/profile/#me"
+    }
+  ],
+  "licenseUri": "http://opensource.org/licenses/MIT",
+  "reportUri": null,
+  "specificationUris": [
+    "http://www.w3.org/TR/sparql11-query/",
+    "http://www.w3.org/TR/sparql11-update/"
+  ]
+}

--- a/spec/parser.js
+++ b/spec/parser.js
@@ -1,0 +1,12 @@
+const { ErrorSkipped } = require('rdf-test-suite');
+const { Parser } = require('..');
+
+module.exports = {
+  parse: async function (query, options) {
+    const parser = new Parser({ baseIRI: options.baseIRI });
+    parser.parse(query);
+  },
+  query: function() {
+    return Promise.reject(new ErrorSkipped('Querying is not supported'));
+  },
+};


### PR DESCRIPTION
This adds [rdf-test-suite](https://github.com/rubensworks/rdf-test-suite.js) as a dev dependency to run the SPARQL query and update test suite.
It skips all tests that execute queries, and only runs the syntax tests.

At the moment, a few query tests fail (those reported in https://github.com/comunica/comunica/issues/287), but also a few update queries fail that have not been reported before.

For the moment, I've added the `-e` flag to disable Travis build failures on test failures. Once spec compliance is restored, this flag should be removed to detect future regressions.