### PR TITLE
add option to create full generator instance

### DIFF
--- a/lib/SparqlGenerator.js
+++ b/lib/SparqlGenerator.js
@@ -391,6 +391,7 @@ module.exports = function SparqlGenerator(options = {}) {
       var currentOptions = Object.create(options);
       options.prefixes = query.prefixes;
       return new Generator(options).toQuery(query);
-    }
+    },
+      generator: function() { return new Generator(options); }
   };
 };


### PR DESCRIPTION
the implementation seems to be well-factored to permit an application to serialize arbitrary algebra nodes.
the interface requires just to be able to get a handle on a full generator instance.
this adds a `generator` function which yields one configured with the original options.