### PR TITLE
Fix generating triples using shorthand notation when subject/predicate is the same

### DIFF
--- a/lib/SparqlGenerator.js
+++ b/lib/SparqlGenerator.js
@@ -109,11 +109,11 @@ Generator.prototype.encodeTriples = function (triples) {
   if (!triples.length)
     return '';
 
-  var parts = [], subject = '', predicate = '';
+  var parts = [], subject = undefined, predicate = undefined;
   for (var i = 0; i < triples.length; i++) {
     var triple = triples[i];
     // Triple with different subject
-    if (triple.subject !== subject) {
+    if (!equalTerms(triple.subject, subject)) {
       // Terminate previous triple
       if (subject)
         parts.push('.' + this._newline);
@@ -122,7 +122,7 @@ Generator.prototype.encodeTriples = function (triples) {
       parts.push(this.toEntity(subject), ' ', this.toEntity(predicate));
     }
     // Triple with same subject but different predicate
-    else if (triple.predicate !== predicate) {
+    else if (!equalTerms(triple.predicate, predicate)) {
       predicate = triple.predicate;
       parts.push(';' + this._newline, this._indent, this.toEntity(predicate));
     }
@@ -372,6 +372,21 @@ function isString(object) { return typeof object === 'string'; }
 
 // Checks whether the object is a Term
 function isTerm(object) { return !!object.termType; }
+
+// Checks whether term1 and term2 are equivalent without `.equals()` prototype method
+function equalTerms(term1, term2) {
+  if (!term1 || !isTerm(term1)) { return false; }
+  if (!term2 || !isTerm(term2)) { return false; }
+  if (term1.termType !== term2.termType) { return false; }
+  switch (term1.termType) {
+    case 'Literal':
+      return term1.value === term2.value
+        && term1.language === term2.language
+        && equalTerms(term1.datatype, term2.datatype);
+    default:
+      return term1.value === term2.value;
+  }
+}
 
 // Maps the array with the given function, and joins the results using the separator
 function mapJoin(array, sep, func, self) {

--- a/test/SparqlGenerator-test.js
+++ b/test/SparqlGenerator-test.js
@@ -63,4 +63,24 @@ describe('A SPARQL generator', function () {
       'SELECT * WHERE { ?s rdfs:label ?o. }';
     expect(generatedQuery).toEqual(expectedQuery);
   });
+
+  it('should separate triples with same subject by semicolon', function () {
+    var parser = new SparqlParser();
+    var parsedQuery = parser.parse('SELECT * WHERE { <t:s> <t:p1> <t:o1>; <t:p2> <t:o2> }');
+    var generatedQuery = defaultGenerator.stringify(parsedQuery);
+    var expectedQuery =
+      'SELECT * WHERE {\n' +
+      '  <t:s> <t:p1> <t:o1>;\n' +
+      '    <t:p2> <t:o2>.\n' +
+      '}';
+    expect(generatedQuery).toEqual(expectedQuery);
+  });
+
+  it('should separate triples with same subject and predicate by comma', function () {
+    var parser = new SparqlParser();
+    var parsedQuery = parser.parse('SELECT * WHERE { <t:s> <t:p> <t:o1>, <t:o2> }');
+    var generatedQuery = defaultGenerator.stringify(parsedQuery);
+    var expectedQuery = 'SELECT * WHERE { <t:s> <t:p> <t:o1>, <t:o2>. }';
+    expect(generatedQuery).toEqual(expectedQuery);
+  });
 });


### PR DESCRIPTION
Hi @RubenVerborgh !

While updating our SPARQL.js dependency to v3.0 at [metaphacts](https://github.com/metaphacts) we discovered that some queries are generated without short notation for triple sequence with the same subject or subject-predicate.

Here is an attempt to fix it by structurally comparing RDF/JS terms. There is a helper method `equalTerms()` defined to avoid using `Term.equals()` method as it's not available when de-serializing query from JSON.

In addition we prepared correct TypeScript typings for SPARQL.js v3.0 (issue #98) which will publish soon on DefinitelyTyped 😄 