### PR TITLE
Add `omitStringDatatype` option to generate simple literals for RDF literal terms with xsd:string datatype

### DIFF
--- a/lib/SparqlGenerator.js
+++ b/lib/SparqlGenerator.js
@@ -1,4 +1,5 @@
 var XSD_INTEGER = 'http://www.w3.org/2001/XMLSchema#integer';
+var XSD_STRING = 'http://www.w3.org/2001/XMLSchema#string';
 
 function Generator(options) {
   this._options = options = options || {};
@@ -279,6 +280,8 @@ Generator.prototype.toEntity = function (value) {
         if (datatype.value === XSD_INTEGER && /^\d+$/.test(lexical))
           // Add space to avoid confusion with decimals in broken parsers
           return lexical + ' ';
+        if (datatype.value === XSD_STRING && this._options.omitStringDatatype)
+          return value;
         value += '^^' + this.encodeIRI(datatype.value);
       }
       return value;
@@ -382,15 +385,16 @@ function mapJoin(array, sep, func, self) {
  * @param options {
  *   allPrefixes: boolean,
  *   indentation: string,
- *   newline: string
+ *   newline: string,
+ *   omitStringDatatype: boolean
  * }
  */
 module.exports = function SparqlGenerator(options = {}) {
   return {
     stringify: function (query) {
       var currentOptions = Object.create(options);
-      options.prefixes = query.prefixes;
-      return new Generator(options).toQuery(query);
+      currentOptions.prefixes = query.prefixes;
+      return new Generator(currentOptions).toQuery(query);
     },
     createGenerator: function() { return new Generator(options); }
   };

--- a/test/SparqlGenerator-test.js
+++ b/test/SparqlGenerator-test.js
@@ -63,4 +63,13 @@ describe('A SPARQL generator', function () {
       'SELECT * WHERE { ?s rdfs:label ?o. }';
     expect(generatedQuery).toEqual(expectedQuery);
   });
+
+  it('should omit datatype for xsd:string literal if requested', function () {
+    var parser = new SparqlParser();
+    var parsedQuery = parser.parse('SELECT * WHERE { ?s ?p "foo" }');
+    var generator = new SparqlGenerator({omitStringDatatype: true});
+    var generatedQuery = generator.stringify(parsedQuery);
+    var expectedQuery = 'SELECT * WHERE { ?s ?p "foo". }';
+    expect(generatedQuery).toEqual(expectedQuery);
+  });
 });


### PR DESCRIPTION
This PR adds ability to produce simple literals for RDF/JS Literal terms with `xsd:string` datatype.

With recent move to RDF/JS term representation in SPARQL.js v3.0 every literal created by `DataFactory` interface usually have `xsd:string` as a default datatype. This causes `Generator` to add datatype suffix for each string literal (e.g. `"foo"^^<http://www.w3.org/2001/XMLSchema#string>`) which may be a little verbose.

There is also an interesting related discussion here: https://github.com/w3c/sparql-12/issues/112
