### PR TITLE
Add SPARQL* support to parser and generator

### DIFF
--- a/bin/sparql-to-json
+++ b/bin/sparql-to-json
@@ -16,5 +16,20 @@ source.setEncoding('utf8');
 source.on('data', function (data) { query += data; });
 source.on('end', function () {
   var parseTree = new SparqlParser().parse(query);
-  process.stdout.write(JSON.stringify(parseTree, null, '  ') + '\n');
+  function termReplacer(key, value) {
+    if (isQuad(value)) {
+      // Workaround for N3 Quad.toJSON() missing `termType` property
+      return {termType: 'Quad', ...value};
+    }
+    return value;
+  };
+  process.stdout.write(JSON.stringify(parseTree, termReplacer, '  ') + '\n');
 });
+
+function isQuad(value) {
+  return value && typeof value === 'object'
+    && !!value.subject
+    && !!value.predicate
+    && !!value.object
+    && !!value.graph;
+}

--- a/lib/SparqlGenerator.js
+++ b/lib/SparqlGenerator.js
@@ -285,6 +285,14 @@ Generator.prototype.toEntity = function (value) {
         value += '^^' + this.encodeIRI(datatype.value);
       }
       return value;
+    case 'Quad':
+      return (
+        '<< ' +
+        this.toEntity(value.subject) + ' ' +
+        this.toEntity(value.predicate) + ' ' +
+        this.toEntity(value.object) +
+        ' >>'
+      );
     // IRI
     default:
       return this.encodeIRI(value.value);
@@ -374,7 +382,9 @@ function variableToString(variable){
 function isString(object) { return typeof object === 'string'; }
 
 // Checks whether the object is a Term
-function isTerm(object) { return !!object.termType; }
+function isTerm(object) {
+  return !!object.termType;
+}
 
 // Checks whether term1 and term2 are equivalent without `.equals()` prototype method
 function equalTerms(term1, term2) {
@@ -386,6 +396,11 @@ function equalTerms(term1, term2) {
       return term1.value === term2.value
         && term1.language === term2.language
         && equalTerms(term1.datatype, term2.datatype);
+    case 'Quad':
+      return equalTerms(term1.subject, term2.subject)
+        && equalTerms(term1.predicate, term2.predicate)
+        && equalTerms(term1.object, term2.object)
+        && equalTerms(term1.graph, term2.graph);
     default:
       return term1.value === term2.value;
   }

--- a/lib/sparql.jison
+++ b/lib/sparql.jison
@@ -266,6 +266,13 @@
     }
     return merged;
   }
+
+  function requireRdfStar(value) {
+    if (!Parser.allowRdfStar) {
+      throw new Error('RDF* is not allowed without "allowRdfStar" flag set');
+    }
+    return value;
+  }
 %}
 
 %lex
@@ -365,6 +372,8 @@ PN_LOCAL_ESC          "\\"("_"|"~"|"."|"-"|"!"|"$"|"&"|"'"|"("|")"|"*"|"+"|","|"
 "MINUS"                  return 'MINUS'
 "UNION"                  return 'UNION'
 "FILTER"                 return 'FILTER'
+"<<"                     return '<<'
+">>"                     return '>>'
 ","                      return ','
 "a"                      return 'a'
 "|"                      return '|'
@@ -489,7 +498,7 @@ SubSelect
     ;
 SelectClauseItem
     : VAR -> toVar($1)
-    | '(' Expression 'AS' VAR ')' -> expression($2, { variable: toVar($4) })
+    | '(' (Expression | ConstTriple) 'AS' VAR ')' -> expression($2, { variable: toVar($4) })
     ;
 ConstructQuery
     : 'CONSTRUCT' ConstructTemplate DatasetClause* WhereClause SolutionModifier -> extend({ queryType: 'CONSTRUCT', template: $2 }, groupDatasets($3), $4, $5)
@@ -652,7 +661,7 @@ GraphPatternNotTriples
     | 'GRAPH' (VAR | iri) GroupGraphPattern -> extend($3, { type: 'graph', name: toVar($2) })
     | 'SERVICE' 'SILENT'? (VAR | iri) GroupGraphPattern -> extend($4, { type: 'service', name: toVar($3), silent: !!$2 })
     | 'FILTER' Constraint -> { type: 'filter', expression: $2 }
-    | 'BIND' '(' Expression 'AS' VAR ')' -> { type: 'bind', variable: toVar($5), expression: $3 }
+    | 'BIND' '(' (Expression | ConstTriple) 'AS' VAR ')' -> { type: 'bind', variable: toVar($5), expression: $3 }
     | ValuesClause
     ;
 Constraint
@@ -675,7 +684,7 @@ ConstructTriples
     : (TriplesSameSubject '.')* TriplesSameSubject '.'? -> unionAll($1, [$2])
     ;
 TriplesSameSubject
-    : VarOrTerm PropertyListNotEmpty -> $2.map(function (t) { return extend(triple($1), t); })
+    : (VarOrTerm | VarTriple) PropertyListNotEmpty -> $2.map(function (t) { return extend(triple($1), t); })
     | TriplesNode PropertyList -> appendAllTo($2.map(function (t) { return extend(triple($1.entity), t); }), $1.triples) /* the subject is a blank node, possibly with more triples */
     ;
 PropertyList
@@ -699,7 +708,7 @@ ObjectList
     : (GraphNode ',')* GraphNode -> appendTo($1, $2)
     ;
 TriplesSameSubjectPath
-    : VarOrTerm PropertyListPathNotEmpty -> $2.map(function (t) { return extend(triple($1), t); })
+    : (VarOrTerm | VarTriple) PropertyListPathNotEmpty -> $2.map(function (t) { return extend(triple($1), t); })
     | TriplesNodePath PropertyListPathNotEmpty? -> !$2 ? $1.triples : appendAllTo($2.map(function (t) { return extend(triple($1.entity), t); }), $1.triples) /* the subject is a blank node, possibly with more triples */
     ;
 PropertyListPathNotEmpty
@@ -747,16 +756,25 @@ TriplesNodePath
     | '[' PropertyListPathNotEmpty ']' -> createAnonymousObject($2)
     ;
 GraphNode
-    : VarOrTerm -> { entity: $1, triples: [] } /* for consistency with TriplesNode */
+    : (VarOrTerm | VarTriple) -> { entity: $1, triples: [] } /* for consistency with TriplesNode */
     | TriplesNode
     ;
 GraphNodePath
-    : VarOrTerm -> { entity: $1, triples: [] } /* for consistency with TriplesNodePath */
+    : (VarOrTerm | VarTriple) -> { entity: $1, triples: [] } /* for consistency with TriplesNodePath */
     | TriplesNodePath
+    ;
+VarTriple
+    : '<<' VarOrTerm Verb VarOrTerm '>>' -> requireRdfStar(Parser.factory.quad($2, $3, $4))
+    ;
+ConstTriple
+    : '<<' Term Verb Term '>>' -> requireRdfStar(Parser.factory.quad($2, $3, $4))
     ;
 VarOrTerm
     : VAR -> toVar($1)
-    | iri
+    | Term
+    ;
+Term
+    : iri
     | Literal
     | BLANK_NODE_LABEL -> blank($1.replace(/^(_:)/,''));
     | ANON -> blank()

--- a/package-lock.json
+++ b/package-lock.json
@@ -1789,9 +1789,9 @@
       "dev": true
     },
     "n3": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/n3/-/n3-1.5.0.tgz",
-      "integrity": "sha512-k4R/EOMnnRYFt+hXgqyKOHjzmshaLuHUFgrz5nsp9nAojCZuAHrro/DsIM2tS0Bgx6ed7DM5Ks3q2teJ8n7HnQ==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/n3/-/n3-1.6.0.tgz",
+      "integrity": "sha512-wqnhi/NhD/O4Tt/SK1dgiC1hLJWG7nwmvh5n7wFDKlxI8QlmvyxmY1b9deVh1D08GCZJtDYvwdmJ5EdZXgp9bg==",
       "requires": {
         "queue-microtask": "^1.1.2"
       }
@@ -2056,9 +2056,9 @@
       "dev": true
     },
     "queue-microtask": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.1.3.tgz",
-      "integrity": "sha512-zC1ZDLKFhZSa8vAdFbkOGouHcOUMgUAI/2/3on/KktpY+BaVqABkzDSsCSvJfmLbICOnrEuF9VIMezZf+T0mBA=="
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.1.4.tgz",
+      "integrity": "sha512-eY/4Obve9cE5FK8YvC1cJsm5cr7XvAurul8UtBDJ2PR1p5NmAwHtvAt5ftcLtwYRCUKNhxCneZZlxmUDFoSeKA=="
     },
     "rdf-isomorphic": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "node": ">=8.0"
   },
   "dependencies": {
-    "n3": "^1.5.0"
+    "n3": "^1.6.0"
   },
   "devDependencies": {
     "expect": "^24.8.0",

--- a/queries/sparql-star-1.sparql
+++ b/queries/sparql-star-1.sparql
@@ -1,0 +1,8 @@
+PREFIX ex: <http://example.com/>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+
+SELECT * WHERE {
+    <<?s ?p ?o>> ex:author ex:Bob .
+    << ex:Moscow a ex:City >> ex:author ?person .
+    << _:b ex:x () >> ex:broken true .
+}

--- a/queries/sparql-star-2.sparql
+++ b/queries/sparql-star-2.sparql
@@ -1,0 +1,6 @@
+PREFIX ex: <http://example.com/>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+
+SELECT ?spb (<<ex:Moscow a ex:City>> as ?moscow) WHERE {
+    BIND(<< ex:SaintPetersburg a ex:City >> as ?spb)
+}

--- a/sparql.js
+++ b/sparql.js
@@ -6,10 +6,14 @@ var N3 = require('n3');
 module.exports = {
   /**
    * Creates a SPARQL parser with the given pre-defined prefixes and base IRI
-   * @param prefixes { [prefix: string]: string }
-   * @param baseIRI string
+   * @param options {
+   *   prefixes?: { [prefix: string]: string },
+   *   baseIRI?: string,
+   *   factory?: import('rdf-js').DataFactory,
+   *   allowRdfStar?: boolean,
+   * }
    */
-  Parser: function ({ prefixes, baseIRI, factory } = {}) {
+  Parser: function ({ prefixes, baseIRI, factory, allowRdfStar } = {}) {
     // Create a copy of the prefixes
     var prefixesCopy = {};
     for (var prefix in prefixes || {})
@@ -22,6 +26,7 @@ module.exports = {
       Parser.base = baseIRI || '';
       Parser.prefixes = Object.create(prefixesCopy);
       Parser.factory = factory || N3.DataFactory;
+      Parser.allowRdfStar = Boolean(allowRdfStar);
       return Parser.prototype.parse.apply(parser, arguments);
     };
     parser._resetBlanks = Parser._resetBlanks;

--- a/test/SparqlGenerator-test.js
+++ b/test/SparqlGenerator-test.js
@@ -30,7 +30,7 @@ describe('A SPARQL generator', function () {
       var parsedQuery = parseJSON(fs.readFileSync(parsedQueryFile, 'utf8').replace(/g_/g, 'e_'));
       var genQuery = allPrefixesGenerator.stringify(parsedQuery);
 
-      const parsed = new SparqlParser().parse(genQuery);
+      const parsed = new SparqlParser({ allowRdfStar: true }).parse(genQuery);
       expect(parsed).toEqualParsedQuery(parsedQuery);
     });
   });

--- a/test/SparqlParser-test.js
+++ b/test/SparqlParser-test.js
@@ -13,7 +13,7 @@ var queriesPath = __dirname + '/../queries/';
 var parsedQueriesPath = __dirname + '/../test/parsedQueries/';
 
 describe('A SPARQL parser', function () {
-  var parser = new SparqlParser();
+  var parser = new SparqlParser({ allowRdfStar: true });
 
   // Ensure the same blank node identifiers are used in every test
   beforeEach(function () { parser._resetBlanks(); });
@@ -166,6 +166,29 @@ describe('A SPARQL parser', function () {
       var result = '[{"type":"union","patterns":[{"type":"bgp","triples":[{"subject":{"termType":"Variable","value":"s"},"predicate":{"termType":"Variable","value":"p"},"object":{"termType":"Variable","value":"o"}}]},{"type":"bgp","triples":[{"subject":{"termType":"Variable","value":"a"},"predicate":{"termType":"Variable","value":"b"},"object":{"termType":"Variable","value":"c"}}]}]}]';
 
       expect(parser.parse(query).where).toEqualParsedQuery(parseJSON(result));
+    });
+  });
+
+  describe('without RDF* support enabled', function () {
+    var parser = new SparqlParser({ allowRdfStar: false });
+    const expectedErrorMessage = 'RDF* is not allowed without "allowRdfStar" flag set';
+
+    it('should throw an error on RDF* triple in projection', function () {
+      expect(() => parser.parse(
+        'SELECT (<< <ex:s> a <ex:o> >> as ?x) WHERE { }'
+      )).toThrow(expectedErrorMessage);
+    });
+
+    it('should throw an error on RDF* triple in BGP', function () {
+      expect(() => parser.parse(
+        'SELECT * WHERE { << ?s ?p ?o >> ?p2 ?o2 }'
+      )).toThrow(expectedErrorMessage);
+    });
+
+    it('should throw an error on RDF* triple in BIND', function () {
+      expect(() => parser.parse(
+        'SELECT * WHERE { BIND(<< <ex:s> <ex:p> 42 >> as ?x) }'
+      )).toThrow(expectedErrorMessage);
     });
   });
 });

--- a/test/parsedQueries/sparql-star-1.json
+++ b/test/parsedQueries/sparql-star-1.json
@@ -1,0 +1,113 @@
+{
+  "queryType": "SELECT",
+  "variables": [
+    {
+      "termType": "Wildcard",
+      "value": "*"
+    }
+  ],
+  "where": [
+    {
+      "type": "bgp",
+      "triples": [
+        {
+          "subject": {
+            "termType": "Quad",
+            "subject": {
+              "termType": "Variable",
+              "value": "s"
+            },
+            "predicate": {
+              "termType": "Variable",
+              "value": "p"
+            },
+            "object": {
+              "termType": "Variable",
+              "value": "o"
+            },
+            "graph": {
+              "termType": "DefaultGraph",
+              "value": ""
+            }
+          },
+          "predicate": {
+            "termType": "NamedNode",
+            "value": "http://example.com/author"
+          },
+          "object": {
+            "termType": "NamedNode",
+            "value": "http://example.com/Bob"
+          }
+        },
+        {
+          "subject": {
+            "termType": "Quad",
+            "subject": {
+              "termType": "NamedNode",
+              "value": "http://example.com/Moscow"
+            },
+            "predicate": {
+              "termType": "NamedNode",
+              "value": "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+            },
+            "object": {
+              "termType": "NamedNode",
+              "value": "http://example.com/City"
+            },
+            "graph": {
+              "termType": "DefaultGraph",
+              "value": ""
+            }
+          },
+          "predicate": {
+            "termType": "NamedNode",
+            "value": "http://example.com/author"
+          },
+          "object": {
+            "termType": "Variable",
+            "value": "person"
+          }
+        },
+        {
+          "subject": {
+            "termType": "Quad",
+            "subject": {
+              "termType": "BlankNode",
+              "value": "e_b"
+            },
+            "predicate": {
+              "termType": "NamedNode",
+              "value": "http://example.com/x"
+            },
+            "object": {
+              "termType": "NamedNode",
+              "value": "http://www.w3.org/1999/02/22-rdf-syntax-ns#nil"
+            },
+            "graph": {
+              "termType": "DefaultGraph",
+              "value": ""
+            }
+          },
+          "predicate": {
+            "termType": "NamedNode",
+            "value": "http://example.com/broken"
+          },
+          "object": {
+            "termType": "Literal",
+            "value": "true",
+            "language": "",
+            "datatype": {
+              "termType": "NamedNode",
+              "value": "http://www.w3.org/2001/XMLSchema#boolean"
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "type": "query",
+  "prefixes": {
+    "ex": "http://example.com/",
+    "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+  }
+}

--- a/test/parsedQueries/sparql-star-2.json
+++ b/test/parsedQueries/sparql-star-2.json
@@ -1,0 +1,67 @@
+{
+  "queryType": "SELECT",
+  "variables": [
+    {
+      "termType": "Variable",
+      "value": "spb"
+    },
+    {
+      "expression": {
+        "termType": "Quad",
+        "subject": {
+          "termType": "NamedNode",
+          "value": "http://example.com/Moscow"
+        },
+        "predicate": {
+          "termType": "NamedNode",
+          "value": "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+        },
+        "object": {
+          "termType": "NamedNode",
+          "value": "http://example.com/City"
+        },
+        "graph": {
+          "termType": "DefaultGraph",
+          "value": ""
+        }
+      },
+      "variable": {
+        "termType": "Variable",
+        "value": "moscow"
+      }
+    }
+  ],
+  "where": [
+    {
+      "type": "bind",
+      "variable": {
+        "termType": "Variable",
+        "value": "spb"
+      },
+      "expression": {
+        "termType": "Quad",
+        "subject": {
+          "termType": "NamedNode",
+          "value": "http://example.com/SaintPetersburg"
+        },
+        "predicate": {
+          "termType": "NamedNode",
+          "value": "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+        },
+        "object": {
+          "termType": "NamedNode",
+          "value": "http://example.com/City"
+        },
+        "graph": {
+          "termType": "DefaultGraph",
+          "value": ""
+        }
+      }
+    }
+  ],
+  "type": "query",
+  "prefixes": {
+    "ex": "http://example.com/",
+    "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+  }
+}


### PR DESCRIPTION
This is a draft implementation of SPARQL* support in parser and generator from our team at metaphacts.
(It fixes #105)

I'm not very familiar with parser rules structure but I tried my best at making as little changes as possible to support triple references (`<<s p o>>`).
Also the generator currently explicitly checks if a term is a quad which won't be needed in the future (as `Quad` will implement `Term` interface).
