### PR TITLE
Check for projection of ungrouped variables

### DIFF
--- a/lib/sparql.jison
+++ b/lib/sparql.jison
@@ -281,7 +281,7 @@
       return [expression];
     } else if (expression.type === "operation") {
       const aggregates = [];
-      for (let arg of expression.args) {
+      for (const arg of expression.args) {
         aggregates.push(...getAggregatesOfExpression(arg));
       }
       return aggregates;

--- a/lib/sparql.jison
+++ b/lib/sparql.jison
@@ -541,7 +541,7 @@ SelectQuery
           }
         }
       }
-      return extend($1, groupDatasets($2), $3, $4)
+      $$ = extend($1, groupDatasets($2), $3, $4)
     }
     ;
 SelectClauseWildcard

--- a/lib/sparql.jison
+++ b/lib/sparql.jison
@@ -302,6 +302,18 @@
     return variables;
   }
 
+  // Help function to flatten arrays
+  function flatten(input, depth = 1, stack = []) {
+    for (let item of input) {
+        if (item instanceof Array && depth > 0) {
+          flatten(item, depth - 1, stack);
+        } else {
+          stack.push(item);
+        }
+    }
+    return stack;
+}
+
 %}
 
 %lex
@@ -511,7 +523,7 @@ SelectQuery
     | SelectClauseVars     DatasetClause* WhereClause SolutionModifier
     {
       // Check for projection of ungrouped variable
-      const counts = $1.variables.map(vars => getAggregatesOfExpression(vars.expression)).flat()
+      const counts = flatten($1.variables.map(vars => getAggregatesOfExpression(vars.expression)))
         .filter(agg => agg.aggregation === "count");
       if (counts.length > 0 || $4.group) {
         for (const selectVar of $1.variables) {

--- a/lib/sparql.jison
+++ b/lib/sparql.jison
@@ -269,7 +269,7 @@
 
   // Return the id of an expression
   function getExpressionId(expression) {
-    return expression.variable ? expression.variable.id : expression.id || expression.expression.id;
+    return expression.variable ? expression.variable.value : expression.value || expression.expression.value;
   }
 
   // Get all "aggregate"'s from an expression
@@ -528,14 +528,14 @@ SelectQuery
       if (counts || $4.group) {
         for (const selectVar of $1.variables) {
           if (selectVar.termType === "Variable") {
-            if (!$4.group || !$4.group.map(groupVar => getExpressionId(groupVar)).includes(selectVar.id)) {
-              throw Error("Projection of ungrouped variable (" + selectVar.id + ")");
+            if (!$4.group || !$4.group.map(groupVar => getExpressionId(groupVar)).includes(getExpressionId(selectVar))) {
+              throw Error("Projection of ungrouped variable (?" + getExpressionId(selectVar) + ")");
             }
           } else if (getAggregatesOfExpression(selectVar.expression).length === 0) {
             const usedVars = getVariablesFromOperation(selectVar.expression);
             for (const usedVar of usedVars) {
-              if (!$4.group.map(groupVar => getExpressionId(groupVar)).includes(usedVar.id)) {
-                throw Error("Use of ungrouped variable in projection of operation (" + usedVar.id + ")");
+              if (!$4.group.map(groupVar => getExpressionId(groupVar)).includes(getExpressionId(usedVar))) {
+                throw Error("Use of ungrouped variable in projection of operation (?" + getExpressionId(usedVar) + ")");
               }
             }
           }

--- a/test/SparqlParser-test.js
+++ b/test/SparqlParser-test.js
@@ -45,6 +45,27 @@ describe('A SPARQL parser', function () {
     expect(error.message).toContain('Parse error on line 1');
   });
 
+  it('should throw an error on a projection of ungrouped variable', function () {
+    var query = 'PREFIX : <http://www.example.org/> SELECT ?o WHERE { ?s ?p ?o } GROUP BY ?s', error = null;
+    try { parser.parse(query); }
+    catch (e) { error = e; }
+
+    expect(error).not.toBeUndefined();
+    expect(error).toBeInstanceOf(Error);
+    expect(error.message).toContain("Projection of ungrouped variable (?o)");
+  });
+
+  it('should throw an error on a use of an ungrouped variable for a projection of an operation', function () {
+    var query = 'PREFIX : <http://www.example.org/> SELECT ?o (?o + ?p AS ?c) WHERE { ?s ?p ?o } GROUP BY (?o)';
+    var error = null;
+    try { parser.parse(query); }
+    catch (e) { error = e; }
+
+    expect(error).not.toBeUndefined();
+    expect(error).toBeInstanceOf(Error);
+    expect(error.message).toContain("Use of ungrouped variable in projection of operation (?p)");
+  });
+
   it('should preserve BGP and filter pattern order', function () {
     var parser = new SparqlParser();
     var query = 'SELECT * { ?s ?p "1" . FILTER(true) . ?s ?p "2"  }';


### PR DESCRIPTION
Closes #83 
Closes #91 
Fixes following tests of test suite:

[x] syn-bad-02.rq (http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_44)
[x] COUNT 8 (http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg08)
[x] COUNT 9 (http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg09) (http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_44) 
[x] COUNT 10 (http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg10)
[x] COUNT 11 (http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg11)
[x] COUNT 12 (http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg12)
[x] Group-6 (http://www.w3.org/2009/sparql/docs/tests/data-sparql11/grouping/manifest#group06)
[x] Group-7 (http://www.w3.org/2009/sparql/docs/tests/data-sparql11/grouping/manifest#group07)