### PR TITLE
Fix bind and select scope

### DIFF
--- a/lib/sparql.jison
+++ b/lib/sparql.jison
@@ -589,7 +589,7 @@ SelectQuery
       if (subqueries.length > 0) {
         const selectedVarIds = $1.variables.filter(v => v.variable.id || undefined).map(v => v.variable.id);
         const subqueryIds = subqueries.flatMap(sub => sub.variables).map(v => v.id || v.variable.id);
-        for (const selectVarId of selectedVarIds) {
+        for (const selectedVarId of selectedVarIds) {
           if (subqueryIds.indexOf(selectedVarId) >= 0) {
             throw Error("Target id of 'AS' (" + selectedVarId + ") already used in subquery");
           }

--- a/lib/sparql.jison
+++ b/lib/sparql.jison
@@ -322,9 +322,9 @@
     if (pattern.triples) {
       const boundVars = [];
       for (const triple of pattern.triples) {
-        if (isVariable(triple.subject)) boundVars.push(triple.subject.id);
-        if (isVariable(triple.predicate)) boundVars.push(triple.predicate.id);
-        if (isVariable(triple.object)) boundVars.push(triple.object.id);
+        if (isVariable(triple.subject)) boundVars.push(triple.subject.value);
+        if (isVariable(triple.predicate)) boundVars.push(triple.predicate.value);
+        if (isVariable(triple.object)) boundVars.push(triple.object.value);
       }
       return boundVars;
     } else if (pattern.patterns) {
@@ -587,11 +587,11 @@ SelectQuery
       // Check if id of each AS-selected column is not yet bound by subquery
       const subqueries = $3.where.filter(w => w.type === "query");
       if (subqueries.length > 0) {
-        const selectedVarIds = $1.variables.filter(v => v.variable.id || undefined).map(v => v.variable.id);
-        const subqueryIds = flatten(subqueries.map(sub => sub.variables)).map(v => v.id || v.variable.id);
+        const selectedVarIds = $1.variables.filter(v => v.variable.value || undefined).map(v => v.variable.value);
+        const subqueryIds = flatten(subqueries.map(sub => sub.variables)).map(v => v.value || v.variable.value);
         for (const selectedVarId of selectedVarIds) {
           if (subqueryIds.indexOf(selectedVarId) >= 0) {
-            throw Error("Target id of 'AS' (" + selectedVarId + ") already used in subquery");
+            throw Error("Target id of 'AS' (?" + selectedVarId + ") already used in subquery");
           }
         }
       }
@@ -605,10 +605,10 @@ SelectClauseVars
     : SelectClauseBase SelectClauseItem+
     {
       // Check if id of each selected column is different
-      const selectedVarIds = $2.map(v => v.id || v.variable.id);
+      const selectedVarIds = $2.map(v => v.value || v.variable.value);
       const duplicates = getDuplicatesInArray(selectedVarIds);
       if (duplicates.length > 0) {
-        throw Error("Two or more of the resulting columns have the same name (" + duplicates[0] + ")");
+        throw Error("Two or more of the resulting columns have the same name (?" + duplicates[0] + ")");
       }
 
       $$ = extend($1, { variables: $2 })
@@ -775,8 +775,8 @@ GroupGraphPattern
           }
         }
         // If binding with a non-free variable, throw error
-        if (boundVars.has(binding.variable.id)) {
-          throw Error("Variable used to bind is already bound (" + binding.variable.id + ")");
+        if (boundVars.has(binding.variable.value)) {
+          throw Error("Variable used to bind is already bound (?" + binding.variable.value + ")");
         }
       }
       $$ = { type: 'group', patterns: $2 }

--- a/lib/sparql.jison
+++ b/lib/sparql.jison
@@ -588,14 +588,13 @@ SelectQuery
       const subqueries = $3.where.filter(w => w.type === "query");
       if (subqueries.length > 0) {
         const selectedVarIds = $1.variables.filter(v => v.variable.id || undefined).map(v => v.variable.id);
-        const subqueryIds = subqueries.flatMap(sub => sub.variables).map(v => v.id || v.variable.id);
+        const subqueryIds = flatten(subqueries.map(sub => sub.variables)).map(v => v.id || v.variable.id);
         for (const selectedVarId of selectedVarIds) {
           if (subqueryIds.indexOf(selectedVarId) >= 0) {
             throw Error("Target id of 'AS' (" + selectedVarId + ") already used in subquery");
           }
         }
       }
-      
       $$ = extend($1, groupDatasets($2), $3, $4)
     }
     ;

--- a/lib/sparql.jison
+++ b/lib/sparql.jison
@@ -587,8 +587,8 @@ SelectQuery
       // Check if id of each AS-selected column is not yet bound by subquery
       const subqueries = $3.where.filter(w => w.type === "query");
       if (subqueries.length > 0) {
-        let selectedVarIds = $1.variables.filter(v => v.variable.id || undefined).map(v => v.variable.id);
-        let subqueryIds = subqueries.flatMap(sub => sub.variables).map(v => v.id || v.variable.id);
+        const selectedVarIds = $1.variables.filter(v => v.variable.id || undefined).map(v => v.variable.id);
+        const subqueryIds = subqueries.flatMap(sub => sub.variables).map(v => v.id || v.variable.id);
         for (const selectVarId of selectedVarIds) {
           if (subqueryIds.indexOf(selectedVarId) >= 0) {
             throw Error("Target id of 'AS' (" + selectedVarId + ") already used in subquery");
@@ -766,13 +766,13 @@ GroupGraphPattern
     | '{' GroupGraphPatternSub '}'
     {
       // For every binding
-      for (let binding of $2.filter(el => el.type === "bind")) {
+      for (const binding of $2.filter(el => el.type === "bind")) {
         const index = $2.indexOf(binding);
         const boundVars = new Set();
         //Collect all bounded variables before the binding
         for (const el of $2.slice(0, index)) {
           if (el.type === "group" || el.type === "bgp") {
-            boundVars.add(...getBoundVarsFromGroupGraphPattern(el));
+            getBoundVarsFromGroupGraphPattern(el).forEach(boundVar => boundVars.add(boundVar));
           }
         }
         // If binding with a non-free variable, throw error

--- a/lib/sparql.jison
+++ b/lib/sparql.jison
@@ -768,16 +768,16 @@ GroupGraphPattern
       // For every binding
       for (let binding of $2.filter(el => el.type === "bind")) {
         const index = $2.indexOf(binding);
-        const boundVars = [];
+        const boundVars = new Set();
         //Collect all bounded variables before the binding
         for (const el of $2.slice(0, index)) {
           if (el.type === "group" || el.type === "bgp") {
-            boundVars.push(...getBoundVarsFromGroupGraphPattern(el));
+            boundVars.add(...getBoundVarsFromGroupGraphPattern(el));
           }
         }
         // If binding with a non-free variable, throw error
-        if (boundVars.includes(binding.variable.id)) {
-          throw Error("Variable used to bind is already bound");
+        if (boundVars.has(binding.variable.id)) {
+          throw Error("Variable used to bind is already bound (" + binding.variable.id + ")");
         }
       }
       $$ = { type: 'group', patterns: $2 }

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "spec-base-update": "rdf-test-suite spec/parser.js http://w3c.github.io/rdf-tests/sparql11/data-sparql11/manifest-all.ttl -s http://www.w3.org/TR/sparql11-update/ -c .rdf-test-suite-cache/",
     "spec-earl-query": "npm run spec-base-query --silent -- -o earl -p spec/earl-meta.json > spec/earl-query.ttl",
     "spec-earl-update": "npm run spec-base-update --silent -- -o earl -p spec/earl-meta.json > spec/earl-update.ttl",
-    "spec": "npm run spec-base-query -- -e && npm run spec-base-update -- -e"
+    "spec": "npm run spec-base-query -- && npm run spec-base-update -- -e"
   },
   "engines": {
     "node": ">=8.0"

--- a/test/SparqlParser-test.js
+++ b/test/SparqlParser-test.js
@@ -47,6 +47,7 @@ describe('A SPARQL parser', function () {
 
   it('should throw an error on a projection of ungrouped variable', function () {
     var query = 'PREFIX : <http://www.example.org/> SELECT ?o WHERE { ?s ?p ?o } GROUP BY ?s', error = null;
+    var error = null;
     try { parser.parse(query); }
     catch (e) { error = e; }
 
@@ -65,6 +66,28 @@ describe('A SPARQL parser', function () {
     expect(error).toBeInstanceOf(Error);
     expect(error.message).toContain("Use of ungrouped variable in projection of operation (?p)");
   });
+
+  it('should throw an error on an invalid bindscope', function () {
+    var query = "PREFIX : <http://www.example.org> SELECT * WHERE {{:s :p ?o . :s :q ?o1 .} BIND((1+?o) AS ?o1)}";
+    var error = null;
+    try { parser.parse(query); }
+    catch (e) { error = e; }
+
+    expect(error).not.toBeUndefined();
+    expect(error).toBeInstanceOf(Error);
+    expect(error.message).toContain("Variable used to bind is already bound (?o1)");
+  });
+
+  it('should throw an error on an invalid selectscope', function () {
+    var query = "SELECT (1 AS ?X ) { SELECT (2 AS ?X ) {} }";
+    var error = null;
+    try { parser.parse(query); }
+    catch (e) { error = e; }
+
+    expect(error).not.toBeUndefined();
+    expect(error).toBeInstanceOf(Error);
+    expect(error.message).toContain("Target id of 'AS' (?X) already used in subquery");
+  }); 
 
   it('should preserve BGP and filter pattern order', function () {
     var parser = new SparqlParser();


### PR DESCRIPTION
This branch is rebased upon #108 so that PR needs to be merged before this one!

Closes #82 

Fixes the following tests:
[x] syn-bad-03.rq (http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_45)
[x] syntax-BINDscope6.rq (http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_60)
[x] syntax-BINDscope7.rq (http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_61a)
[x] syntax-BINDscope8.rq (http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_62a)
[x] syntax-SELECTscope2 (http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_65)