### PR TITLE
Add SPARQL* support

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 The [SPARQL 1.1 Query Language](http://www.w3.org/TR/sparql11-query/) allows to query datasources of [RDF triples](http://www.w3.org/TR/rdf11-concepts/).
 SPARQL.js translates SPARQL into JSON and back,
 so you can parse and build SPARQL queries in your JavaScript applications.
+It also contains support for the [SPARQL*](https://blog.liu.se/olafhartig/2019/01/10/position-statement-rdf-star-and-sparql-star/) extension
+under the `strictMode` argument.
 
 It fully supports the [SPARQL 1.1 specification](http://www.w3.org/TR/sparql11-query/), including [property paths](http://www.w3.org/TR/sparql11-query/#propertypaths), [federation](http://www.w3.org/TR/sparql11-federated-query/), and [updates](http://www.w3.org/TR/sparql11-update/).
 
@@ -21,14 +23,17 @@ var parsedQuery = parser.parse(
 
 // Regenerate a SPARQL query from a JSON object
 var SparqlGenerator = require('sparqljs').Generator;
-var generator = new SparqlGenerator({ /* prefixes, baseIRI, factory */ });
+var generator = new SparqlGenerator({ /* prefixes, baseIRI, factory, strictMode */ });
 parsedQuery.variables = ['?mickey'];
 var generatedQuery = generator.stringify(parsedQuery);
 ```
+set strictMode to false to disallow [SPARQL*](https://blog.liu.se/olafhartig/2019/01/10/position-statement-rdf-star-and-sparql-star/).
 ### Standalone
 ```bash
-$ sparql-to-json query.sparql
+$ sparql-to-json --strict query.sparql
 ```
+Parse [SPARQL*](https://blog.liu.se/olafhartig/2019/01/10/position-statement-rdf-star-and-sparql-star/) syntax by default.
+For pure [SPARQL 1.1](http://www.w3.org/TR/sparql11-query/), use the `--strict` flag.
 
 ## Representation
 Queries are represented in a JSON structure. The most easy way to get acquainted with this structure is to try the examples in the `queries` folder through `sparql-to-json`. All examples of the [SPARQL 1.1 specification](http://www.w3.org/TR/sparql11-query/) have been included, in case you wonder how a specific syntactical construct is represented.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The [SPARQL 1.1 Query Language](http://www.w3.org/TR/sparql11-query/) allows to 
 SPARQL.js translates SPARQL into JSON and back,
 so you can parse and build SPARQL queries in your JavaScript applications.
 It also contains support for the [SPARQL*](https://blog.liu.se/olafhartig/2019/01/10/position-statement-rdf-star-and-sparql-star/) extension
-under the `strictMode` argument.
+under the `sparqlStar` option.
 
 It fully supports the [SPARQL 1.1 specification](http://www.w3.org/TR/sparql11-query/), including [property paths](http://www.w3.org/TR/sparql11-query/#propertypaths), [federation](http://www.w3.org/TR/sparql11-federated-query/), and [updates](http://www.w3.org/TR/sparql11-update/).
 
@@ -23,11 +23,11 @@ var parsedQuery = parser.parse(
 
 // Regenerate a SPARQL query from a JSON object
 var SparqlGenerator = require('sparqljs').Generator;
-var generator = new SparqlGenerator({ /* prefixes, baseIRI, factory, strictMode */ });
+var generator = new SparqlGenerator({ /* prefixes, baseIRI, factory, sparqlStar */ });
 parsedQuery.variables = ['?mickey'];
 var generatedQuery = generator.stringify(parsedQuery);
 ```
-set strictMode to false to disallow [SPARQL*](https://blog.liu.se/olafhartig/2019/01/10/position-statement-rdf-star-and-sparql-star/).
+Set `sparqlStar` to `true` to allow [SPARQL*](https://blog.liu.se/olafhartig/2019/01/10/position-statement-rdf-star-and-sparql-star/) syntax.
 ### Standalone
 ```bash
 $ sparql-to-json --strict query.sparql

--- a/bin/sparql-to-json
+++ b/bin/sparql-to-json
@@ -22,6 +22,6 @@ var query = '', source = args[0] ? fs.createReadStream(args[0]) : process.stdin;
 source.setEncoding('utf8');
 source.on('data', function (data) { query += data; });
 source.on('end', function () {
-  var parseTree = new SparqlParser({ strictMode }).parse(query);
+  var parseTree = new SparqlParser({ sparqlStar: !strictMode }).parse(query);
   process.stdout.write(JSON.stringify(parseTree, null, '  ') + '\n');
 });

--- a/bin/sparql-to-json
+++ b/bin/sparql-to-json
@@ -2,9 +2,16 @@
 
 // Parse arguments
 var args = process.argv.slice(2);
+let inStrictMode = false;
 if (args.length > 1) {
-  console.error('usage: sparql-to-json query.sparql');
-  return process.exit(1);
+  if (args[0] !== '--strict') {
+    console.error('usage: sparql-to-json query.sparql');
+    return process.exit(1);
+  } else {
+    inStrictMode = true;
+    // Shift arguments
+    args.shift();
+  }
 }
 
 var fs = require('fs'),
@@ -15,6 +22,6 @@ var query = '', source = args[0] ? fs.createReadStream(args[0]) : process.stdin;
 source.setEncoding('utf8');
 source.on('data', function (data) { query += data; });
 source.on('end', function () {
-  var parseTree = new SparqlParser().parse(query);
+  var parseTree = new SparqlParser({ inStrictMode }).parse(query);
   process.stdout.write(JSON.stringify(parseTree, null, '  ') + '\n');
 });

--- a/bin/sparql-to-json
+++ b/bin/sparql-to-json
@@ -2,13 +2,13 @@
 
 // Parse arguments
 var args = process.argv.slice(2);
-let inStrictMode = false;
+let strictMode = false;
 if (args.length > 1) {
   if (args[0] !== '--strict') {
     console.error('usage: sparql-to-json query.sparql');
     return process.exit(1);
   } else {
-    inStrictMode = true;
+    strictMode = true;
     // Shift arguments
     args.shift();
   }
@@ -22,6 +22,6 @@ var query = '', source = args[0] ? fs.createReadStream(args[0]) : process.stdin;
 source.setEncoding('utf8');
 source.on('data', function (data) { query += data; });
 source.on('end', function () {
-  var parseTree = new SparqlParser({ inStrictMode }).parse(query);
+  var parseTree = new SparqlParser({ strictMode }).parse(query);
   process.stdout.write(JSON.stringify(parseTree, null, '  ') + '\n');
 });

--- a/bin/sparql-to-json
+++ b/bin/sparql-to-json
@@ -16,5 +16,20 @@ source.setEncoding('utf8');
 source.on('data', function (data) { query += data; });
 source.on('end', function () {
   var parseTree = new SparqlParser().parse(query);
-  process.stdout.write(JSON.stringify(parseTree, null, '  ') + '\n');
+  function termReplacer(key, value) {
+    if (isQuad(value)) {
+      // Workaround for N3 Quad.toJSON() missing `termType` property
+      return {termType: 'Quad', ...value};
+    }
+    return value;
+  };
+  process.stdout.write(JSON.stringify(parseTree, termReplacer, '  ') + '\n');
 });
+
+function isQuad(value) {
+  return value && typeof value === 'object'
+    && !!value.subject
+    && !!value.predicate
+    && !!value.object
+    && !!value.graph;
+}

--- a/bin/sparql-to-json
+++ b/bin/sparql-to-json
@@ -16,20 +16,5 @@ source.setEncoding('utf8');
 source.on('data', function (data) { query += data; });
 source.on('end', function () {
   var parseTree = new SparqlParser().parse(query);
-  function termReplacer(key, value) {
-    if (isQuad(value)) {
-      // Workaround for N3 Quad.toJSON() missing `termType` property
-      return {termType: 'Quad', ...value};
-    }
-    return value;
-  };
-  process.stdout.write(JSON.stringify(parseTree, termReplacer, '  ') + '\n');
+  process.stdout.write(JSON.stringify(parseTree, null, '  ') + '\n');
 });
-
-function isQuad(value) {
-  return value && typeof value === 'object'
-    && !!value.subject
-    && !!value.predicate
-    && !!value.object
-    && !!value.graph;
-}

--- a/lib/SparqlGenerator.js
+++ b/lib/SparqlGenerator.js
@@ -285,6 +285,14 @@ Generator.prototype.toEntity = function (value) {
         value += '^^' + this.encodeIRI(datatype.value);
       }
       return value;
+    case 'Quad':
+      return (
+        '<< ' +
+        this.toEntity(value.subject) + ' ' +
+        this.toEntity(value.predicate) + ' ' +
+        this.toEntity(value.object) +
+        ' >>'
+      );
     // IRI
     default:
       return this.encodeIRI(value.value);
@@ -374,7 +382,9 @@ function variableToString(variable){
 function isString(object) { return typeof object === 'string'; }
 
 // Checks whether the object is a Term
-function isTerm(object) { return !!object.termType; }
+function isTerm(object) {
+  return !!object.termType;
+}
 
 // Checks whether term1 and term2 are equivalent without `.equals()` prototype method
 function equalTerms(term1, term2) {
@@ -386,6 +396,11 @@ function equalTerms(term1, term2) {
       return term1.value === term2.value
         && term1.language === term2.language
         && equalTerms(term1.datatype, term2.datatype);
+    case 'Quad':
+      return equalTerms(term1.subject, term2.subject)
+        && equalTerms(term1.predicate, term2.predicate)
+        && equalTerms(term1.object, term2.object)
+        && equalTerms(term1.graph, term2.graph);
     default:
       return term1.value === term2.value;
   }

--- a/lib/SparqlGenerator.js
+++ b/lib/SparqlGenerator.js
@@ -383,7 +383,7 @@ function isString(object) { return typeof object === 'string'; }
 
 // Checks whether the object is a Term
 function isTerm(object) {
-  return !!object.termType;
+  return typeof object.termType === 'string';
 }
 
 // Checks whether term1 and term2 are equivalent without `.equals()` prototype method

--- a/lib/SparqlGenerator.js
+++ b/lib/SparqlGenerator.js
@@ -394,13 +394,13 @@ function equalTerms(term1, term2) {
   switch (term1.termType) {
     case 'Literal':
       return term1.value === term2.value
-        && term1.language === term2.language
-        && equalTerms(term1.datatype, term2.datatype);
+          && term1.language === term2.language
+          && equalTerms(term1.datatype, term2.datatype);
     case 'Quad':
       return equalTerms(term1.subject, term2.subject)
-        && equalTerms(term1.predicate, term2.predicate)
-        && equalTerms(term1.object, term2.object)
-        && equalTerms(term1.graph, term2.graph);
+          && equalTerms(term1.predicate, term2.predicate)
+          && equalTerms(term1.object, term2.object)
+          && equalTerms(term1.graph, term2.graph);
     default:
       return term1.value === term2.value;
   }

--- a/lib/sparql.jison
+++ b/lib/sparql.jison
@@ -314,9 +314,9 @@
     return stack;
 }
 
-  function ifNotStrictMode(value) {
-    if (Parser.strictMode) {
-      throw new Error('SPARQL* is not allowed in strict mode');
+  function allowsRdfStar(value) {
+    if (!Parser.sparqlStar) {
+      throw new Error('SPARQL* support is not enabled');
     }
     return value;
   }
@@ -833,10 +833,10 @@ GraphNodePath
     | TriplesNodePath
     ;
 VarTriple
-    : '<<' (VarTriple | VarOrTerm) Verb (VarTriple | VarOrTerm) '>>' -> ifNotStrictMode(Parser.factory.quad($2, $3, $4))
+    : '<<' (VarTriple | VarOrTerm) Verb (VarTriple | VarOrTerm) '>>' -> allowsRdfStar(Parser.factory.quad($2, $3, $4))
     ;
 ConstTriple
-    : '<<' (ConstTriple | Term) Verb (ConstTriple | Term) '>>' -> ifNotStrictMode(Parser.factory.quad($2, $3, $4))
+    : '<<' (ConstTriple | Term) Verb (ConstTriple | Term) '>>' -> allowsRdfStar(Parser.factory.quad($2, $3, $4))
     ;
 VarOrTerm
     : VAR -> toVar($1)

--- a/lib/sparql.jison
+++ b/lib/sparql.jison
@@ -287,7 +287,7 @@
       return aggregates;
     }
     return [];
-  } 
+  }
 
   // Get all variables used in an operation
   function getVariablesFromOperation(operation) {
@@ -314,6 +314,12 @@
     return stack;
 }
 
+  function requireRdfStar(value) {
+    if (!Parser.allowRdfStar) {
+      throw new Error('RDF* is not allowed without "allowRdfStar" flag set');
+    }
+    return value;
+  }
 %}
 
 %lex
@@ -413,6 +419,8 @@ PN_LOCAL_ESC          "\\"("_"|"~"|"."|"-"|"!"|"$"|"&"|"'"|"("|")"|"*"|"+"|","|"
 "MINUS"                  return 'MINUS'
 "UNION"                  return 'UNION'
 "FILTER"                 return 'FILTER'
+"<<"                     return '<<'
+">>"                     return '>>'
 ","                      return ','
 "a"                      return 'a'
 "|"                      return '|'
@@ -559,7 +567,7 @@ SubSelect
     ;
 SelectClauseItem
     : VAR -> toVar($1)
-    | '(' Expression 'AS' VAR ')' -> expression($2, { variable: toVar($4) })
+    | '(' (Expression | ConstTriple) 'AS' VAR ')' -> expression($2, { variable: toVar($4) })
     ;
 ConstructQuery
     : 'CONSTRUCT' ConstructTemplate DatasetClause* WhereClause SolutionModifier -> extend({ queryType: 'CONSTRUCT', template: $2 }, groupDatasets($3), $4, $5)
@@ -722,7 +730,7 @@ GraphPatternNotTriples
     | 'GRAPH' (VAR | iri) GroupGraphPattern -> extend($3, { type: 'graph', name: toVar($2) })
     | 'SERVICE' 'SILENT'? (VAR | iri) GroupGraphPattern -> extend($4, { type: 'service', name: toVar($3), silent: !!$2 })
     | 'FILTER' Constraint -> { type: 'filter', expression: $2 }
-    | 'BIND' '(' Expression 'AS' VAR ')' -> { type: 'bind', variable: toVar($5), expression: $3 }
+    | 'BIND' '(' (Expression | ConstTriple) 'AS' VAR ')' -> { type: 'bind', variable: toVar($5), expression: $3 }
     | ValuesClause
     ;
 Constraint
@@ -745,7 +753,7 @@ ConstructTriples
     : (TriplesSameSubject '.')* TriplesSameSubject '.'? -> unionAll($1, [$2])
     ;
 TriplesSameSubject
-    : VarOrTerm PropertyListNotEmpty -> $2.map(function (t) { return extend(triple($1), t); })
+    : (VarOrTerm | VarTriple) PropertyListNotEmpty -> $2.map(function (t) { return extend(triple($1), t); })
     | TriplesNode PropertyList -> appendAllTo($2.map(function (t) { return extend(triple($1.entity), t); }), $1.triples) /* the subject is a blank node, possibly with more triples */
     ;
 PropertyList
@@ -769,7 +777,7 @@ ObjectList
     : (GraphNode ',')* GraphNode -> appendTo($1, $2)
     ;
 TriplesSameSubjectPath
-    : VarOrTerm PropertyListPathNotEmpty -> $2.map(function (t) { return extend(triple($1), t); })
+    : (VarOrTerm | VarTriple) PropertyListPathNotEmpty -> $2.map(function (t) { return extend(triple($1), t); })
     | TriplesNodePath PropertyListPathNotEmpty? -> !$2 ? $1.triples : appendAllTo($2.map(function (t) { return extend(triple($1.entity), t); }), $1.triples) /* the subject is a blank node, possibly with more triples */
     ;
 PropertyListPathNotEmpty
@@ -817,16 +825,25 @@ TriplesNodePath
     | '[' PropertyListPathNotEmpty ']' -> createAnonymousObject($2)
     ;
 GraphNode
-    : VarOrTerm -> { entity: $1, triples: [] } /* for consistency with TriplesNode */
+    : (VarOrTerm | VarTriple) -> { entity: $1, triples: [] } /* for consistency with TriplesNode */
     | TriplesNode
     ;
 GraphNodePath
-    : VarOrTerm -> { entity: $1, triples: [] } /* for consistency with TriplesNodePath */
+    : (VarOrTerm | VarTriple) -> { entity: $1, triples: [] } /* for consistency with TriplesNodePath */
     | TriplesNodePath
+    ;
+VarTriple
+    : '<<' VarOrTerm Verb VarOrTerm '>>' -> requireRdfStar(Parser.factory.quad($2, $3, $4))
+    ;
+ConstTriple
+    : '<<' Term Verb Term '>>' -> requireRdfStar(Parser.factory.quad($2, $3, $4))
     ;
 VarOrTerm
     : VAR -> toVar($1)
-    | iri
+    | Term
+    ;
+Term
+    : iri
     | Literal
     | BLANK_NODE_LABEL -> blank($1.replace(/^(_:)/,''));
     | ANON -> blank()

--- a/lib/sparql.jison
+++ b/lib/sparql.jison
@@ -315,7 +315,7 @@
 }
 
   function ifNotStrictMode(value) {
-    if (Parser.inStrictMode) {
+    if (Parser.strictMode) {
       throw new Error('SPARQL* is not allowed in strict mode');
     }
     return value;

--- a/lib/sparql.jison
+++ b/lib/sparql.jison
@@ -833,10 +833,10 @@ GraphNodePath
     | TriplesNodePath
     ;
 VarTriple
-    : '<<' (VarTriple | VarOrTerm) Verb (VarTriple | VarOrTerm) '>>' -> Parser.factory.quad($2, $3, $4)
+    : '<<' (VarTriple | VarOrTerm) Verb (VarTriple | VarOrTerm) '>>' -> requireRdfStar(Parser.factory.quad($2, $3, $4))
     ;
 ConstTriple
-    : '<<' (ConstTriple | Term) Verb (ConstTriple | Term) '>>' -> Parser.factory.quad($2, $3, $4)
+    : '<<' (ConstTriple | Term) Verb (ConstTriple | Term) '>>' -> requireRdfStar(Parser.factory.quad($2, $3, $4))
     ;
 VarOrTerm
     : VAR -> toVar($1)

--- a/lib/sparql.jison
+++ b/lib/sparql.jison
@@ -314,9 +314,9 @@
     return stack;
 }
 
-  function requireRdfStar(value) {
-    if (!Parser.allowRdfStar) {
-      throw new Error('RDF* is not allowed without "allowRdfStar" flag set');
+  function ifNotStrictMode(value) {
+    if (Parser.inStrictMode) {
+      throw new Error('RDF* is not allowed in strict mode');
     }
     return value;
   }
@@ -833,10 +833,10 @@ GraphNodePath
     | TriplesNodePath
     ;
 VarTriple
-    : '<<' (VarTriple | VarOrTerm) Verb (VarTriple | VarOrTerm) '>>' -> requireRdfStar(Parser.factory.quad($2, $3, $4))
+    : '<<' (VarTriple | VarOrTerm) Verb (VarTriple | VarOrTerm) '>>' -> ifNotStrictMode(Parser.factory.quad($2, $3, $4))
     ;
 ConstTriple
-    : '<<' (ConstTriple | Term) Verb (ConstTriple | Term) '>>' -> requireRdfStar(Parser.factory.quad($2, $3, $4))
+    : '<<' (ConstTriple | Term) Verb (ConstTriple | Term) '>>' -> ifNotStrictMode(Parser.factory.quad($2, $3, $4))
     ;
 VarOrTerm
     : VAR -> toVar($1)

--- a/lib/sparql.jison
+++ b/lib/sparql.jison
@@ -833,10 +833,10 @@ GraphNodePath
     | TriplesNodePath
     ;
 VarTriple
-    : '<<' VarOrTerm Verb VarOrTerm '>>' -> requireRdfStar(Parser.factory.quad($2, $3, $4))
+    : '<<' (VarTriple | VarOrTerm) Verb (VarTriple | VarOrTerm) '>>' -> Parser.factory.quad($2, $3, $4)
     ;
 ConstTriple
-    : '<<' Term Verb Term '>>' -> requireRdfStar(Parser.factory.quad($2, $3, $4))
+    : '<<' (ConstTriple | Term) Verb (ConstTriple | Term) '>>' -> Parser.factory.quad($2, $3, $4)
     ;
 VarOrTerm
     : VAR -> toVar($1)

--- a/lib/sparql.jison
+++ b/lib/sparql.jison
@@ -316,7 +316,7 @@
 
   function ifNotStrictMode(value) {
     if (Parser.inStrictMode) {
-      throw new Error('RDF* is not allowed in strict mode');
+      throw new Error('SPARQL* is not allowed in strict mode');
     }
     return value;
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1789,9 +1789,9 @@
       "dev": true
     },
     "n3": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/n3/-/n3-1.5.0.tgz",
-      "integrity": "sha512-k4R/EOMnnRYFt+hXgqyKOHjzmshaLuHUFgrz5nsp9nAojCZuAHrro/DsIM2tS0Bgx6ed7DM5Ks3q2teJ8n7HnQ==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/n3/-/n3-1.6.0.tgz",
+      "integrity": "sha512-wqnhi/NhD/O4Tt/SK1dgiC1hLJWG7nwmvh5n7wFDKlxI8QlmvyxmY1b9deVh1D08GCZJtDYvwdmJ5EdZXgp9bg==",
       "requires": {
         "queue-microtask": "^1.1.2"
       }
@@ -2056,9 +2056,9 @@
       "dev": true
     },
     "queue-microtask": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.1.3.tgz",
-      "integrity": "sha512-zC1ZDLKFhZSa8vAdFbkOGouHcOUMgUAI/2/3on/KktpY+BaVqABkzDSsCSvJfmLbICOnrEuF9VIMezZf+T0mBA=="
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.1.4.tgz",
+      "integrity": "sha512-eY/4Obve9cE5FK8YvC1cJsm5cr7XvAurul8UtBDJ2PR1p5NmAwHtvAt5ftcLtwYRCUKNhxCneZZlxmUDFoSeKA=="
     },
     "rdf-isomorphic": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "node": ">=8.0"
   },
   "dependencies": {
-    "n3": "^1.5.0"
+    "n3": "^1.6.0"
   },
   "devDependencies": {
     "expect": "^24.8.0",

--- a/queries/sparq-star-1.sparql
+++ b/queries/sparq-star-1.sparql
@@ -1,0 +1,8 @@
+PREFIX ex: <http://example.com/>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+
+SELECT * WHERE {
+    <<?s ?p ?o>> ex:author ex:Bob .
+    << ex:Moscow a ex:City >> ex:author ?person .
+    << _:b ex:x () >> ex:broken true .
+}

--- a/queries/sparq-star-1.sparql
+++ b/queries/sparq-star-1.sparql
@@ -1,8 +1,0 @@
-PREFIX ex: <http://example.com/>
-PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
-
-SELECT * WHERE {
-    <<?s ?p ?o>> ex:author ex:Bob .
-    << ex:Moscow a ex:City >> ex:author ?person .
-    << _:b ex:x () >> ex:broken true .
-}

--- a/queries/sparq-star-2.sparql
+++ b/queries/sparq-star-2.sparql
@@ -1,0 +1,6 @@
+PREFIX ex: <http://example.com/>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+
+SELECT ?spb (<<ex:Moscow a ex:City>> as ?moscow) WHERE {
+    BIND(<< ex:SaintPetersburg a ex:City >> as ?spb)
+}

--- a/queries/sparql-star-1.sparql
+++ b/queries/sparql-star-1.sparql
@@ -1,0 +1,8 @@
+PREFIX ex: <http://example.com/>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+
+SELECT * WHERE {
+    <<?s ?p ?o>> ex:author ex:Bob .
+    << ex:Moscow a ex:City >> ex:author ?person .
+    << _:b ex:x () >> ex:broken true .
+}

--- a/queries/sparql-star-2.sparql
+++ b/queries/sparql-star-2.sparql
@@ -1,0 +1,6 @@
+PREFIX ex: <http://example.com/>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+
+SELECT ?spb (<<ex:Moscow a ex:City>> as ?moscow) WHERE {
+    BIND(<< ex:SaintPetersburg a ex:City >> as ?spb)
+}

--- a/queries/sparql-star-bind-nested-1.sparql
+++ b/queries/sparql-star-bind-nested-1.sparql
@@ -1,0 +1,6 @@
+PREFIX ex: <http://example.com/>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+
+SELECT * WHERE {
+    BIND(<< << ex:SaintPetersburg a ex:City >> ex:author ex:b >> as ?spb)
+}

--- a/queries/sparql-star-bind-nested-2.sparql
+++ b/queries/sparql-star-bind-nested-2.sparql
@@ -1,0 +1,6 @@
+PREFIX ex: <http://example.com/>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+
+SELECT * WHERE {
+    BIND(<< ex:a ex:b << ex:SaintPetersburg a ex:City >> >> as ?spb)
+}

--- a/queries/sparql-star-bind.sparql
+++ b/queries/sparql-star-bind.sparql
@@ -1,0 +1,6 @@
+PREFIX ex: <http://example.com/>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+
+SELECT * WHERE {
+    BIND(<< ex:SaintPetersburg a ex:City >> as ?spb)
+}

--- a/queries/sparql-star-nested-1.sparql
+++ b/queries/sparql-star-nested-1.sparql
@@ -1,0 +1,3 @@
+SELECT * WHERE {
+  <<<<?s1 ?p1 ?o1>> ?p2 ?o2>> ?p3 ?o3
+}

--- a/queries/sparql-star-nested-2.sparql
+++ b/queries/sparql-star-nested-2.sparql
@@ -1,0 +1,3 @@
+SELECT * WHERE {
+  ?s1 ?p1 <<?s2 ?p2 <<?s3 ?p3 ?o3>>>>
+}

--- a/queries/sparql-star-select-bind-nested-1.sparql
+++ b/queries/sparql-star-select-bind-nested-1.sparql
@@ -1,0 +1,6 @@
+PREFIX ex: <http://example.com/>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+
+SELECT ?spb (<<<<ex:Moscow a ex:City>> ex:author ex:b>> as ?author) WHERE {
+    ex:a ex:name ex:c
+}

--- a/queries/sparql-star-select-bind-nested-2.sparql
+++ b/queries/sparql-star-select-bind-nested-2.sparql
@@ -1,0 +1,6 @@
+PREFIX ex: <http://example.com/>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+
+SELECT ?spb (<<ex:a ex:author <<ex:a ex:b ex:c>>>> as ?author) WHERE {
+    ex:a ex:name ex:c
+}

--- a/queries/sparql-star-select-bind.sparql
+++ b/queries/sparql-star-select-bind.sparql
@@ -2,5 +2,5 @@ PREFIX ex: <http://example.com/>
 PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 
 SELECT ?spb (<<ex:Moscow a ex:City>> as ?moscow) WHERE {
-    BIND(<< ex:SaintPetersburg a ex:City >> as ?spb)
+    ex:a ex:name ex:c
 }

--- a/sparql.js
+++ b/sparql.js
@@ -10,10 +10,10 @@ module.exports = {
    *   prefixes?: { [prefix: string]: string },
    *   baseIRI?: string,
    *   factory?: import('rdf-js').DataFactory,
-   *   inStrictMode?: boolean,
+   *   strictMode?: boolean,
    * }
    */
-  Parser: function ({ prefixes, baseIRI, factory, inStrictMode } = {}) {
+  Parser: function ({ prefixes, baseIRI, factory, strictMode } = {}) {
     // Create a copy of the prefixes
     var prefixesCopy = {};
     for (var prefix in prefixes || {})
@@ -26,7 +26,7 @@ module.exports = {
       Parser.base = baseIRI || '';
       Parser.prefixes = Object.create(prefixesCopy);
       Parser.factory = factory || N3.DataFactory;
-      Parser.inStrictMode = Boolean(inStrictMode);
+      Parser.strictMode = Boolean(strictMode);
       return Parser.prototype.parse.apply(parser, arguments);
     };
     parser._resetBlanks = Parser._resetBlanks;

--- a/sparql.js
+++ b/sparql.js
@@ -6,10 +6,14 @@ var N3 = require('n3');
 module.exports = {
   /**
    * Creates a SPARQL parser with the given pre-defined prefixes and base IRI
-   * @param prefixes { [prefix: string]: string }
-   * @param baseIRI string
+   * @param options {
+   *   prefixes?: { [prefix: string]: string },
+   *   baseIRI?: string,
+   *   factory?: import('rdf-js').DataFactory,
+   *   allowRdfStar?: boolean,
+   * }
    */
-  Parser: function ({ prefixes, baseIRI, factory } = {}) {
+  Parser: function ({ prefixes, baseIRI, factory, allowRdfStar } = {}) {
     // Create a copy of the prefixes
     var prefixesCopy = {};
     for (var prefix in prefixes || {})
@@ -22,6 +26,7 @@ module.exports = {
       Parser.base = baseIRI || '';
       Parser.prefixes = Object.create(prefixesCopy);
       Parser.factory = factory || N3.DataFactory;
+      Parser.allowRdfStar = Boolean(allowRdfStar);
       return Parser.prototype.parse.apply(parser, arguments);
     };
     parser._resetBlanks = Parser._resetBlanks;

--- a/sparql.js
+++ b/sparql.js
@@ -26,7 +26,7 @@ module.exports = {
       Parser.base = baseIRI || '';
       Parser.prefixes = Object.create(prefixesCopy);
       Parser.factory = factory || N3.DataFactory;
-      Parser.strictMode = Boolean(strictMode);
+      Parser.strictMode = Boolean(strictMode) || typeof strictMode === "undefined";
       return Parser.prototype.parse.apply(parser, arguments);
     };
     parser._resetBlanks = Parser._resetBlanks;

--- a/sparql.js
+++ b/sparql.js
@@ -10,10 +10,10 @@ module.exports = {
    *   prefixes?: { [prefix: string]: string },
    *   baseIRI?: string,
    *   factory?: import('rdf-js').DataFactory,
-   *   strictMode?: boolean,
+   *   sparqlStar?: boolean,
    * }
    */
-  Parser: function ({ prefixes, baseIRI, factory, strictMode } = {}) {
+  Parser: function ({ prefixes, baseIRI, factory, sparqlStar } = {}) {
     // Create a copy of the prefixes
     var prefixesCopy = {};
     for (var prefix in prefixes || {})
@@ -26,7 +26,7 @@ module.exports = {
       Parser.base = baseIRI || '';
       Parser.prefixes = Object.create(prefixesCopy);
       Parser.factory = factory || N3.DataFactory;
-      Parser.strictMode = Boolean(strictMode) || typeof strictMode === "undefined";
+      Parser.sparqlStar = Boolean(sparqlStar);
       return Parser.prototype.parse.apply(parser, arguments);
     };
     parser._resetBlanks = Parser._resetBlanks;

--- a/sparql.js
+++ b/sparql.js
@@ -10,10 +10,10 @@ module.exports = {
    *   prefixes?: { [prefix: string]: string },
    *   baseIRI?: string,
    *   factory?: import('rdf-js').DataFactory,
-   *   allowRdfStar?: boolean,
+   *   inStrictMode?: boolean,
    * }
    */
-  Parser: function ({ prefixes, baseIRI, factory, allowRdfStar } = {}) {
+  Parser: function ({ prefixes, baseIRI, factory, inStrictMode } = {}) {
     // Create a copy of the prefixes
     var prefixesCopy = {};
     for (var prefix in prefixes || {})
@@ -26,7 +26,7 @@ module.exports = {
       Parser.base = baseIRI || '';
       Parser.prefixes = Object.create(prefixesCopy);
       Parser.factory = factory || N3.DataFactory;
-      Parser.allowRdfStar = Boolean(allowRdfStar);
+      Parser.inStrictMode = Boolean(inStrictMode);
       return Parser.prototype.parse.apply(parser, arguments);
     };
     parser._resetBlanks = Parser._resetBlanks;

--- a/test/SparqlGenerator-test.js
+++ b/test/SparqlGenerator-test.js
@@ -30,7 +30,7 @@ describe('A SPARQL generator', function () {
       var parsedQuery = parseJSON(fs.readFileSync(parsedQueryFile, 'utf8').replace(/g_/g, 'e_'));
       var genQuery = allPrefixesGenerator.stringify(parsedQuery);
 
-      const parsed = new SparqlParser().parse(genQuery);
+      const parsed = new SparqlParser({ allowRdfStar: true }).parse(genQuery);
       expect(parsed).toEqualParsedQuery(parsedQuery);
     });
   });

--- a/test/SparqlGenerator-test.js
+++ b/test/SparqlGenerator-test.js
@@ -30,7 +30,7 @@ describe('A SPARQL generator', function () {
       var parsedQuery = parseJSON(fs.readFileSync(parsedQueryFile, 'utf8').replace(/g_/g, 'e_'));
       var genQuery = allPrefixesGenerator.stringify(parsedQuery);
 
-      const parsed = new SparqlParser({ strictMode: false }).parse(genQuery);
+      const parsed = new SparqlParser({ sparqlStar: true }).parse(genQuery);
       expect(parsed).toEqualParsedQuery(parsedQuery);
     });
   });

--- a/test/SparqlGenerator-test.js
+++ b/test/SparqlGenerator-test.js
@@ -30,7 +30,7 @@ describe('A SPARQL generator', function () {
       var parsedQuery = parseJSON(fs.readFileSync(parsedQueryFile, 'utf8').replace(/g_/g, 'e_'));
       var genQuery = allPrefixesGenerator.stringify(parsedQuery);
 
-      const parsed = new SparqlParser({ inStrictMode: false }).parse(genQuery);
+      const parsed = new SparqlParser({ strictMode: false }).parse(genQuery);
       expect(parsed).toEqualParsedQuery(parsedQuery);
     });
   });

--- a/test/SparqlGenerator-test.js
+++ b/test/SparqlGenerator-test.js
@@ -30,7 +30,7 @@ describe('A SPARQL generator', function () {
       var parsedQuery = parseJSON(fs.readFileSync(parsedQueryFile, 'utf8').replace(/g_/g, 'e_'));
       var genQuery = allPrefixesGenerator.stringify(parsedQuery);
 
-      const parsed = new SparqlParser({ allowRdfStar: true }).parse(genQuery);
+      const parsed = new SparqlParser({ inStrictMode: false }).parse(genQuery);
       expect(parsed).toEqualParsedQuery(parsedQuery);
     });
   });

--- a/test/SparqlParser-test.js
+++ b/test/SparqlParser-test.js
@@ -192,7 +192,7 @@ describe('A SPARQL parser', function () {
 
   describe('without RDF* support enabled', function () {
     var parser = new SparqlParser({ inStrictMode: true });
-    const expectedErrorMessage = 'RDF* is not allowed in strict mode';
+    const expectedErrorMessage = 'SPARQL* is not allowed in strict mode';
 
     it('should throw an error on RDF* triple in projection', function () {
       expect(() => parser.parse(

--- a/test/SparqlParser-test.js
+++ b/test/SparqlParser-test.js
@@ -13,7 +13,7 @@ var queriesPath = __dirname + '/../queries/';
 var parsedQueriesPath = __dirname + '/../test/parsedQueries/';
 
 describe('A SPARQL parser', function () {
-  var parser = new SparqlParser({ strictMode: false });
+  var parser = new SparqlParser({ sparqlStar: true });
 
   // Ensure the same blank node identifiers are used in every test
   beforeEach(function () { parser._resetBlanks(); });
@@ -191,8 +191,8 @@ describe('A SPARQL parser', function () {
   });
 
   describe('without RDF* support enabled', function () {
-    var parser = new SparqlParser({ strictMode: true });
-    const expectedErrorMessage = 'SPARQL* is not allowed in strict mode';
+    var parser = new SparqlParser();
+    const expectedErrorMessage = 'SPARQL* support is not enabled';
 
     it('should throw an error on RDF* triple in projection', function () {
       expect(() => parser.parse(

--- a/test/SparqlParser-test.js
+++ b/test/SparqlParser-test.js
@@ -13,7 +13,7 @@ var queriesPath = __dirname + '/../queries/';
 var parsedQueriesPath = __dirname + '/../test/parsedQueries/';
 
 describe('A SPARQL parser', function () {
-  var parser = new SparqlParser({ inStrictMode: false });
+  var parser = new SparqlParser({ strictMode: false });
 
   // Ensure the same blank node identifiers are used in every test
   beforeEach(function () { parser._resetBlanks(); });
@@ -191,7 +191,7 @@ describe('A SPARQL parser', function () {
   });
 
   describe('without RDF* support enabled', function () {
-    var parser = new SparqlParser({ inStrictMode: true });
+    var parser = new SparqlParser({ strictMode: true });
     const expectedErrorMessage = 'SPARQL* is not allowed in strict mode';
 
     it('should throw an error on RDF* triple in projection', function () {

--- a/test/SparqlParser-test.js
+++ b/test/SparqlParser-test.js
@@ -13,7 +13,7 @@ var queriesPath = __dirname + '/../queries/';
 var parsedQueriesPath = __dirname + '/../test/parsedQueries/';
 
 describe('A SPARQL parser', function () {
-  var parser = new SparqlParser({ allowRdfStar: true });
+  var parser = new SparqlParser({ inStrictMode: false });
 
   // Ensure the same blank node identifiers are used in every test
   beforeEach(function () { parser._resetBlanks(); });
@@ -191,8 +191,8 @@ describe('A SPARQL parser', function () {
   });
 
   describe('without RDF* support enabled', function () {
-    var parser = new SparqlParser({ allowRdfStar: false });
-    const expectedErrorMessage = 'RDF* is not allowed without "allowRdfStar" flag set';
+    var parser = new SparqlParser({ inStrictMode: true });
+    const expectedErrorMessage = 'RDF* is not allowed in strict mode';
 
     it('should throw an error on RDF* triple in projection', function () {
       expect(() => parser.parse(

--- a/test/parsedQueries/sparql-star-1.json
+++ b/test/parsedQueries/sparql-star-1.json
@@ -1,0 +1,113 @@
+{
+  "queryType": "SELECT",
+  "variables": [
+    {
+      "termType": "Wildcard",
+      "value": "*"
+    }
+  ],
+  "where": [
+    {
+      "type": "bgp",
+      "triples": [
+        {
+          "subject": {
+            "termType": "Quad",
+            "subject": {
+              "termType": "Variable",
+              "value": "s"
+            },
+            "predicate": {
+              "termType": "Variable",
+              "value": "p"
+            },
+            "object": {
+              "termType": "Variable",
+              "value": "o"
+            },
+            "graph": {
+              "termType": "DefaultGraph",
+              "value": ""
+            }
+          },
+          "predicate": {
+            "termType": "NamedNode",
+            "value": "http://example.com/author"
+          },
+          "object": {
+            "termType": "NamedNode",
+            "value": "http://example.com/Bob"
+          }
+        },
+        {
+          "subject": {
+            "termType": "Quad",
+            "subject": {
+              "termType": "NamedNode",
+              "value": "http://example.com/Moscow"
+            },
+            "predicate": {
+              "termType": "NamedNode",
+              "value": "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+            },
+            "object": {
+              "termType": "NamedNode",
+              "value": "http://example.com/City"
+            },
+            "graph": {
+              "termType": "DefaultGraph",
+              "value": ""
+            }
+          },
+          "predicate": {
+            "termType": "NamedNode",
+            "value": "http://example.com/author"
+          },
+          "object": {
+            "termType": "Variable",
+            "value": "person"
+          }
+        },
+        {
+          "subject": {
+            "termType": "Quad",
+            "subject": {
+              "termType": "BlankNode",
+              "value": "e_b"
+            },
+            "predicate": {
+              "termType": "NamedNode",
+              "value": "http://example.com/x"
+            },
+            "object": {
+              "termType": "NamedNode",
+              "value": "http://www.w3.org/1999/02/22-rdf-syntax-ns#nil"
+            },
+            "graph": {
+              "termType": "DefaultGraph",
+              "value": ""
+            }
+          },
+          "predicate": {
+            "termType": "NamedNode",
+            "value": "http://example.com/broken"
+          },
+          "object": {
+            "termType": "Literal",
+            "value": "true",
+            "language": "",
+            "datatype": {
+              "termType": "NamedNode",
+              "value": "http://www.w3.org/2001/XMLSchema#boolean"
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "type": "query",
+  "prefixes": {
+    "ex": "http://example.com/",
+    "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+  }
+}

--- a/test/parsedQueries/sparql-star-1.json
+++ b/test/parsedQueries/sparql-star-1.json
@@ -13,6 +13,7 @@
         {
           "subject": {
             "termType": "Quad",
+            "value": "",
             "subject": {
               "termType": "Variable",
               "value": "s"
@@ -42,6 +43,7 @@
         {
           "subject": {
             "termType": "Quad",
+            "value": "",
             "subject": {
               "termType": "NamedNode",
               "value": "http://example.com/Moscow"
@@ -71,6 +73,7 @@
         {
           "subject": {
             "termType": "Quad",
+            "value": "",
             "subject": {
               "termType": "BlankNode",
               "value": "e_b"

--- a/test/parsedQueries/sparql-star-2.json
+++ b/test/parsedQueries/sparql-star-2.json
@@ -8,6 +8,7 @@
     {
       "expression": {
         "termType": "Quad",
+        "value": "",
         "subject": {
           "termType": "NamedNode",
           "value": "http://example.com/Moscow"
@@ -40,6 +41,7 @@
       },
       "expression": {
         "termType": "Quad",
+        "value": "",
         "subject": {
           "termType": "NamedNode",
           "value": "http://example.com/SaintPetersburg"

--- a/test/parsedQueries/sparql-star-2.json
+++ b/test/parsedQueries/sparql-star-2.json
@@ -1,0 +1,67 @@
+{
+  "queryType": "SELECT",
+  "variables": [
+    {
+      "termType": "Variable",
+      "value": "spb"
+    },
+    {
+      "expression": {
+        "termType": "Quad",
+        "subject": {
+          "termType": "NamedNode",
+          "value": "http://example.com/Moscow"
+        },
+        "predicate": {
+          "termType": "NamedNode",
+          "value": "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+        },
+        "object": {
+          "termType": "NamedNode",
+          "value": "http://example.com/City"
+        },
+        "graph": {
+          "termType": "DefaultGraph",
+          "value": ""
+        }
+      },
+      "variable": {
+        "termType": "Variable",
+        "value": "moscow"
+      }
+    }
+  ],
+  "where": [
+    {
+      "type": "bind",
+      "variable": {
+        "termType": "Variable",
+        "value": "spb"
+      },
+      "expression": {
+        "termType": "Quad",
+        "subject": {
+          "termType": "NamedNode",
+          "value": "http://example.com/SaintPetersburg"
+        },
+        "predicate": {
+          "termType": "NamedNode",
+          "value": "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+        },
+        "object": {
+          "termType": "NamedNode",
+          "value": "http://example.com/City"
+        },
+        "graph": {
+          "termType": "DefaultGraph",
+          "value": ""
+        }
+      }
+    }
+  ],
+  "type": "query",
+  "prefixes": {
+    "ex": "http://example.com/",
+    "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+  }
+}

--- a/test/parsedQueries/sparql-star-bind-nested-1.json
+++ b/test/parsedQueries/sparql-star-bind-nested-1.json
@@ -1,0 +1,58 @@
+{
+  "queryType": "SELECT",
+  "variables": [
+    {
+      "termType": "Wildcard"
+    }
+  ],
+  "where": [
+    {
+      "type": "bind",
+      "variable": {
+        "termType": "Variable",
+        "value": "spb"
+      },
+      "expression": {
+        "termType": "Quad",
+        "value": "",
+        "subject": {
+          "termType": "Quad",
+          "value": "",
+          "subject": {
+            "termType": "NamedNode",
+            "value": "http://example.com/SaintPetersburg"
+          },
+          "predicate": {
+            "termType": "NamedNode",
+            "value": "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+          },
+          "object": {
+            "termType": "NamedNode",
+            "value": "http://example.com/City"
+          },
+          "graph": {
+            "termType": "DefaultGraph",
+            "value": ""
+          }
+        },
+        "predicate": {
+          "termType": "NamedNode",
+          "value": "http://example.com/author"
+        },
+        "object": {
+          "termType": "NamedNode",
+          "value": "http://example.com/b"
+        },
+        "graph": {
+          "termType": "DefaultGraph",
+          "value": ""
+        }
+      }
+    }
+  ],
+  "type": "query",
+  "prefixes": {
+    "ex": "http://example.com/",
+    "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+  }
+}

--- a/test/parsedQueries/sparql-star-bind-nested-2.json
+++ b/test/parsedQueries/sparql-star-bind-nested-2.json
@@ -1,0 +1,59 @@
+{
+  "queryType": "SELECT",
+  "variables": [
+    {
+      "termType": "Wildcard",
+      "value": "spb"
+    }
+  ],
+  "where": [
+    {
+      "type": "bind",
+      "variable": {
+        "termType": "Variable",
+        "value": "spb"
+      },
+      "expression": {
+        "termType": "Quad",
+        "value": "",
+        "subject": {
+          "termType": "NamedNode",
+          "value": "http://example.com/a"
+        },
+        "predicate": {
+          "termType": "NamedNode",
+          "value": "http://example.com/b"
+        },
+        "object": {
+          "termType": "Quad",
+          "value": "",
+          "subject": {
+            "termType": "NamedNode",
+            "value": "http://example.com/SaintPetersburg"
+          },
+          "predicate": {
+            "termType": "NamedNode",
+            "value": "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+          },
+          "object": {
+            "termType": "NamedNode",
+            "value": "http://example.com/City"
+          },
+          "graph": {
+            "termType": "DefaultGraph",
+            "value": ""
+          }
+        },
+        "graph": {
+          "termType": "DefaultGraph",
+          "value": ""
+        }
+      }
+    }
+  ],
+  "type": "query",
+  "prefixes": {
+    "ex": "http://example.com/",
+    "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+  }
+}

--- a/test/parsedQueries/sparql-star-bind.json
+++ b/test/parsedQueries/sparql-star-bind.json
@@ -1,0 +1,42 @@
+{
+  "queryType": "SELECT",
+  "variables": [
+    {
+      "termType": "Wildcard"
+    }
+  ],
+  "where": [
+    {
+      "type": "bind",
+      "variable": {
+        "termType": "Variable",
+        "value": "spb"
+      },
+      "expression": {
+        "termType": "Quad",
+        "value": "",
+        "subject": {
+          "termType": "NamedNode",
+          "value": "http://example.com/SaintPetersburg"
+        },
+        "predicate": {
+          "termType": "NamedNode",
+          "value": "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+        },
+        "object": {
+          "termType": "NamedNode",
+          "value": "http://example.com/City"
+        },
+        "graph": {
+          "termType": "DefaultGraph",
+          "value": ""
+        }
+      }
+    }
+  ],
+  "type": "query",
+  "prefixes": {
+    "ex": "http://example.com/",
+    "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+  }
+}

--- a/test/parsedQueries/sparql-star-nested-1.json
+++ b/test/parsedQueries/sparql-star-nested-1.json
@@ -1,0 +1,63 @@
+{
+  "queryType": "SELECT",
+  "variables": [
+    {
+      "termType": "Wildcard"
+    }
+  ],
+  "where": [
+    {
+      "type": "bgp",
+      "triples": [
+        {
+          "subject": {
+            "termType": "Quad",
+            "value": "",
+              "subject": {
+                "termType": "Quad",
+                "value": "",
+                "subject": {
+                  "termType": "Variable",
+                  "value": "s1"
+                },
+                "predicate": {
+                  "termType": "Variable",
+                  "value": "p1"
+                },
+                "object": {
+                  "termType": "Variable",
+                  "value": "o1"
+                },
+                "graph": {
+                  "termType": "DefaultGraph",
+                  "value": ""
+                }
+              },
+              "predicate": {
+                "termType": "Variable",
+                "value": "p2"
+              },
+              "object": {
+                "termType": "Variable",
+                "value": "o2"
+              },
+              "graph": {
+                "termType": "DefaultGraph",
+                "value": ""
+              }
+          },
+          "predicate": {
+            "termType": "Variable",
+            "value": "p3"
+          },
+          "object": {
+            "termType": "Variable",
+            "value": "o3"
+          }
+        }
+      ]
+    }
+  ],
+  "type": "query",
+  "prefixes": {}
+}

--- a/test/parsedQueries/sparql-star-nested-2.json
+++ b/test/parsedQueries/sparql-star-nested-2.json
@@ -1,0 +1,63 @@
+{
+  "queryType": "SELECT",
+  "variables": [
+    {
+      "termType": "Wildcard"
+    }
+  ],
+  "where": [
+    {
+      "type": "bgp",
+      "triples": [
+        {
+          "subject": {
+            "termType": "Variable",
+            "value": "s1"
+          },
+          "predicate": {
+            "termType": "Variable",
+            "value": "p1"
+          },
+          "object": {
+            "termType": "Quad",
+            "value": "",
+            "subject": {
+              "termType": "Variable",
+              "value": "s2"
+            },
+            "predicate": {
+              "termType": "Variable",
+              "value": "p2"
+            },
+            "object": {
+              "termType": "Quad",
+              "value": "",
+              "subject": {
+                "termType": "Variable",
+                "value": "s3"
+              },
+              "predicate": {
+                "termType": "Variable",
+                "value": "p3"
+              },
+              "object": {
+                "termType": "Variable",
+                "value": "o3"
+              },
+              "graph": {
+                "termType": "DefaultGraph",
+                "value": ""
+              }
+            },
+            "graph": {
+              "termType": "DefaultGraph",
+              "value": ""
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "type": "query",
+  "prefixes": {}
+}

--- a/test/parsedQueries/sparql-star-select-bind-nested-1.json
+++ b/test/parsedQueries/sparql-star-select-bind-nested-1.json
@@ -1,0 +1,77 @@
+{
+  "queryType": "SELECT",
+  "variables": [
+    {
+      "termType": "Variable",
+      "value": "spb"
+    },
+    {
+      "expression": {
+        "termType": "Quad",
+        "value": "",
+        "subject": {
+          "termType": "Quad",
+          "value": "",
+          "subject": {
+            "termType": "NamedNode",
+            "value": "http://example.com/Moscow"
+          },
+          "predicate": {
+            "termType": "NamedNode",
+            "value": "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+          },
+          "object": {
+            "termType": "NamedNode",
+            "value": "http://example.com/City"
+          },
+          "graph": {
+            "termType": "DefaultGraph",
+            "value": ""
+          }
+        },
+        "predicate": {
+          "termType": "NamedNode",
+          "value": "http://example.com/author"
+        },
+        "object": {
+          "termType": "NamedNode",
+          "value": "http://example.com/b"
+        },
+        "graph": {
+          "termType": "DefaultGraph",
+          "value": ""
+        }
+      },
+      "variable": {
+        "termType": "Variable",
+        "value": "author"
+      }
+    }
+  ],
+  "where": [
+    {
+      "type": "bgp",
+      "triples": [
+        {
+          "subject": {
+            "termType": "NamedNode",
+            "value": "http://example.com/a"
+          },
+          "predicate": {
+            "termType": "NamedNode",
+            "value": "http://example.com/name"
+          },
+          "object": {
+            "termType": "NamedNode",
+            "value": "http://example.com/c"
+          }
+        }
+      ]
+    }
+  ],
+  "type": "query",
+  "prefixes": {
+    "ex": "http://example.com/",
+    "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+  }
+}

--- a/test/parsedQueries/sparql-star-select-bind-nested-2.json
+++ b/test/parsedQueries/sparql-star-select-bind-nested-2.json
@@ -1,0 +1,77 @@
+{
+  "queryType": "SELECT",
+  "variables": [
+    {
+      "termType": "Variable",
+      "value": "spb"
+    },
+    {
+      "expression": {
+        "termType": "Quad",
+        "value": "",
+        "subject": {
+          "termType": "NamedNode",
+          "value": "http://example.com/a"
+        },
+        "predicate": {
+          "termType": "NamedNode",
+          "value": "http://example.com/author"
+        },
+        "object": {
+          "termType": "Quad",
+          "value": "",
+          "subject": {
+            "termType": "NamedNode",
+            "value": "http://example.com/a"
+          },
+          "predicate": {
+            "termType": "NamedNode",
+            "value": "http://example.com/b"
+          },
+          "object": {
+            "termType": "NamedNode",
+            "value": "http://example.com/c"
+          },
+          "graph": {
+            "termType": "DefaultGraph",
+            "value": ""
+          }
+        },
+        "graph": {
+          "termType": "DefaultGraph",
+          "value": ""
+        }
+      },
+      "variable": {
+        "termType": "Variable",
+        "value": "author"
+      }
+    }
+  ],
+  "where": [
+    {
+      "type": "bgp",
+      "triples": [
+        {
+          "subject": {
+            "termType": "NamedNode",
+            "value": "http://example.com/a"
+          },
+          "predicate": {
+            "termType": "NamedNode",
+            "value": "http://example.com/name"
+          },
+          "object": {
+            "termType": "NamedNode",
+            "value": "http://example.com/c"
+          }
+        }
+      ]
+    }
+  ],
+  "type": "query",
+  "prefixes": {
+    "ex": "http://example.com/",
+    "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+  }
+}

--- a/test/parsedQueries/sparql-star-select-bind.json
+++ b/test/parsedQueries/sparql-star-select-bind.json
@@ -1,0 +1,61 @@
+{
+  "queryType": "SELECT",
+  "variables": [
+    {
+      "termType": "Variable",
+      "value": "spb"
+    },
+    {
+      "expression": {
+        "termType": "Quad",
+        "value": "",
+        "subject": {
+          "termType": "NamedNode",
+          "value": "http://example.com/Moscow"
+        },
+        "predicate": {
+          "termType": "NamedNode",
+          "value": "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+        },
+        "object": {
+          "termType": "NamedNode",
+          "value": "http://example.com/City"
+        },
+        "graph": {
+          "termType": "DefaultGraph",
+          "value": ""
+        }
+      },
+      "variable": {
+        "termType": "Variable",
+        "value": "moscow"
+      }
+    }
+  ],
+  "where": [
+    {
+      "type": "bgp",
+      "triples": [
+        {
+          "subject": {
+            "termType": "NamedNode",
+            "value": "http://example.com/a"
+          },
+          "predicate": {
+            "termType": "NamedNode",
+            "value": "http://example.com/name"
+          },
+          "object": {
+            "termType": "NamedNode",
+            "value": "http://example.com/c"
+          }
+        }
+      ]
+    }
+  ],
+  "type": "query",
+  "prefixes": {
+    "ex": "http://example.com/",
+    "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+  }
+}


### PR DESCRIPTION
This pull request adds SPARQL* support to the parser and generator. It also adds an argument for specifying whether SPARQL* should be allowed or not. The implementation was based on @AlexeyMz's contribution, discussion and initial contribution can be found at PR #106.

Details:
- [x] Support for SPARQL*
- [x] Support for nested triples
- [x] Tests
- [x] Commandline flag and Parser argument `--strict` to specify SPARQL* support
- [ ] Support for quads in the place of triples
- [ ] Update README to reflect the `--strict` argument
