### PR TITLE
Add SPARQL* quad support to parser and generator

### DIFF
--- a/lib/SparqlGenerator.js
+++ b/lib/SparqlGenerator.js
@@ -286,6 +286,16 @@ Generator.prototype.toEntity = function (value) {
       }
       return value;
     case 'Quad':
+      if (value.graph && value.graph.termType !== "DefaultGraph"){
+        return '<< GRAPH ' +
+          this.toEntity(value.graph) +
+          ' { ' +
+          this.toEntity(value.subject) + ' ' +
+          this.toEntity(value.predicate) + ' ' +
+          this.toEntity(value.object) +
+          ' } ' +
+          ' >>'
+      }
       return (
         '<< ' +
         this.toEntity(value.subject) + ' ' +

--- a/lib/sparql.jison
+++ b/lib/sparql.jison
@@ -907,10 +907,12 @@ GraphNodePath
     | TriplesNodePath
     ;
 VarTriple
-    : '<<' (VarTriple | VarOrTerm) Verb (VarTriple | VarOrTerm) '>>' -> ensureSparqlStar(Parser.factory.quad($2, $3, $4))
+    : '<<' 'GRAPH' (VAR | iri) '{' (VarTriple | VarOrTerm) Verb (VarTriple | VarOrTerm) '}' '>>' -> ensureSparqlStar(Parser.factory.quad($5, $6, $7, toVar($3)))
+    | '<<' (VarTriple | VarOrTerm) Verb (VarTriple | VarOrTerm) '>>' -> ensureSparqlStar(Parser.factory.quad($2, $3, $4))
     ;
 ConstTriple
-    : '<<' (ConstTriple | Term) Verb (ConstTriple | Term) '>>' -> ensureSparqlStar(Parser.factory.quad($2, $3, $4))
+    : '<<' 'GRAPH' (VAR | iri) '{' (ConstTriple | Term) Verb (ConstTriple | Term) '}' '>>' -> ensureSparqlStar(Parser.factory.quad($5, $6, $7, toVar($3)))
+    | '<<' (ConstTriple | Term) Verb (ConstTriple | Term) '>>' -> ensureSparqlStar(Parser.factory.quad($2, $3, $4))
     ;
 VarOrTerm
     : VAR -> toVar($1)

--- a/queries/sparql-star-quad-1.sparql
+++ b/queries/sparql-star-quad-1.sparql
@@ -1,0 +1,8 @@
+PREFIX ex: <http://example.com/>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+
+SELECT * WHERE {
+    <<GRAPH ?g {?s ?p ?o}>> ex:author ex:Bob .
+    << GRAPH ex:graph {ex:Moscow a ex:City} >> ex:author ?person .
+    << GRAPH ex:g2 { _:b ex:x () }>> ex:broken true .
+}

--- a/queries/sparql-star-quad-bind.sparql
+++ b/queries/sparql-star-quad-bind.sparql
@@ -1,0 +1,6 @@
+PREFIX ex: <http://example.com/>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+
+SELECT * WHERE {
+    BIND(<< GRAPH ex:g {ex:SaintPetersburg a ex:City} >> as ?spb)
+}

--- a/queries/sparql-star-quad-nested-1.sparql
+++ b/queries/sparql-star-quad-nested-1.sparql
@@ -1,0 +1,6 @@
+PREFIX ex: <http://example.com/>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+
+SELECT * WHERE {
+    << GRAPH ex:graph {<< GRAPH ex:graph {ex:Moscow a ex:City} >> a ex:City} >> ex:author ?person .
+}

--- a/queries/sparql-star-quad-nested-2.sparql
+++ b/queries/sparql-star-quad-nested-2.sparql
@@ -1,0 +1,6 @@
+PREFIX ex: <http://example.com/>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+
+SELECT * WHERE {
+    BIND(<< GRAPH ex:g {<< GRAPH ex:g {ex:SaintPetersburg a ex:City} >> a ex:City} >> as ?spb)
+}

--- a/queries/sparql-star-quad-nested-3.sparql
+++ b/queries/sparql-star-quad-nested-3.sparql
@@ -1,0 +1,6 @@
+PREFIX ex: <http://example.com/>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+
+SELECT (<<GRAPH ex:g {ex:Moscow a <<GRAPH ex:g {ex:Moscow a ex:City}>>}>> as ?moscow) WHERE {
+    ex:a ex:name ex:c
+}

--- a/queries/sparql-star-quad-nested.sparql
+++ b/queries/sparql-star-quad-nested.sparql
@@ -1,0 +1,7 @@
+PREFIX ex: <http://example.com/>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+
+SELECT (<<GRAPH ex:g {ex:Moscow a <<GRAPH ex:g {ex:Moscow a ex:City}>>}>> as ?moscow) WHERE {
+    << GRAPH ex:graph {<< GRAPH ex:graph {ex:Moscow a ex:City} >> a ex:City} >> ex:author ?person .
+    BIND(<< GRAPH ex:g {<< GRAPH ex:g {ex:SaintPetersburg a ex:City} >> a ex:City} >> as ?spb)
+}

--- a/queries/sparql-star-quad-select-bind.sparql
+++ b/queries/sparql-star-quad-select-bind.sparql
@@ -1,0 +1,6 @@
+PREFIX ex: <http://example.com/>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+
+SELECT ?spb (<<GRAPH ex:g {ex:Moscow a ex:City}>> as ?moscow) WHERE {
+    ex:a ex:name ex:c
+}

--- a/test/SparqlParser-test.js
+++ b/test/SparqlParser-test.js
@@ -87,7 +87,7 @@ describe('A SPARQL parser', function () {
     expect(error).not.toBeUndefined();
     expect(error).toBeInstanceOf(Error);
     expect(error.message).toContain("Target id of 'AS' (?X) already used in subquery");
-  }); 
+  });
 
   it('should preserve BGP and filter pattern order', function () {
     var parser = new SparqlParser();

--- a/test/parsedQueries/sparql-star-quad-1.json
+++ b/test/parsedQueries/sparql-star-quad-1.json
@@ -1,0 +1,115 @@
+{
+  "queryType": "SELECT",
+  "variables": [
+    {
+      "termType": "Wildcard"
+    }
+  ],
+  "where": [
+    {
+      "type": "bgp",
+      "triples": [
+        {
+          "subject": {
+            "termType": "Quad",
+            "value": "",
+            "subject": {
+              "termType": "Variable",
+              "value": "s"
+            },
+            "predicate": {
+              "termType": "Variable",
+              "value": "p"
+            },
+            "object": {
+              "termType": "Variable",
+              "value": "o"
+            },
+            "graph": {
+              "termType": "Variable",
+              "value": "g"
+            }
+          },
+          "predicate": {
+            "termType": "NamedNode",
+            "value": "http://example.com/author"
+          },
+          "object": {
+            "termType": "NamedNode",
+            "value": "http://example.com/Bob"
+          }
+        },
+        {
+          "subject": {
+            "termType": "Quad",
+            "value": "",
+            "subject": {
+              "termType": "NamedNode",
+              "value": "http://example.com/Moscow"
+            },
+            "predicate": {
+              "termType": "NamedNode",
+              "value": "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+            },
+            "object": {
+              "termType": "NamedNode",
+              "value": "http://example.com/City"
+            },
+            "graph": {
+              "termType": "NamedNode",
+              "value": "http://example.com/graph"
+            }
+          },
+          "predicate": {
+            "termType": "NamedNode",
+            "value": "http://example.com/author"
+          },
+          "object": {
+            "termType": "Variable",
+            "value": "person"
+          }
+        },
+        {
+          "subject": {
+            "termType": "Quad",
+            "value": "",
+            "subject": {
+              "termType": "BlankNode",
+              "value": "e_b"
+            },
+            "predicate": {
+              "termType": "NamedNode",
+              "value": "http://example.com/x"
+            },
+            "object": {
+              "termType": "NamedNode",
+              "value": "http://www.w3.org/1999/02/22-rdf-syntax-ns#nil"
+            },
+            "graph": {
+              "termType": "NamedNode",
+              "value": "http://example.com/g2"
+            }
+          },
+          "predicate": {
+            "termType": "NamedNode",
+            "value": "http://example.com/broken"
+          },
+          "object": {
+            "termType": "Literal",
+            "value": "true",
+            "language": "",
+            "datatype": {
+              "termType": "NamedNode",
+              "value": "http://www.w3.org/2001/XMLSchema#boolean"
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "type": "query",
+  "prefixes": {
+    "ex": "http://example.com/",
+    "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+  }
+}

--- a/test/parsedQueries/sparql-star-quad-bind.json
+++ b/test/parsedQueries/sparql-star-quad-bind.json
@@ -1,0 +1,42 @@
+{
+  "queryType": "SELECT",
+  "variables": [
+    {
+      "termType": "Wildcard"
+    }
+  ],
+  "where": [
+    {
+      "type": "bind",
+      "variable": {
+        "termType": "Variable",
+        "value": "spb"
+      },
+      "expression": {
+        "termType": "Quad",
+        "value": "",
+        "subject": {
+          "termType": "NamedNode",
+          "value": "http://example.com/SaintPetersburg"
+        },
+        "predicate": {
+          "termType": "NamedNode",
+          "value": "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+        },
+        "object": {
+          "termType": "NamedNode",
+          "value": "http://example.com/City"
+        },
+        "graph": {
+          "termType": "NamedNode",
+          "value": "http://example.com/g"
+        }
+      }
+    }
+  ],
+  "type": "query",
+  "prefixes": {
+    "ex": "http://example.com/",
+    "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+  }
+}

--- a/test/parsedQueries/sparql-star-quad-nested-1.json
+++ b/test/parsedQueries/sparql-star-quad-nested-1.json
@@ -1,0 +1,66 @@
+{
+  "queryType": "SELECT",
+  "variables": [
+    {
+      "termType": "Wildcard"
+    }
+  ],
+  "where": [
+    {
+      "type": "bgp",
+      "triples": [
+        {
+          "subject": {
+            "termType": "Quad",
+            "value": "",
+            "subject": {
+              "termType": "Quad",
+              "value": "",
+              "subject": {
+                "termType": "NamedNode",
+                "value": "http://example.com/Moscow"
+              },
+              "predicate": {
+                "termType": "NamedNode",
+                "value": "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+              },
+              "object": {
+                "termType": "NamedNode",
+                "value": "http://example.com/City"
+              },
+              "graph": {
+                "termType": "NamedNode",
+                "value": "http://example.com/graph"
+              }
+            },
+            "predicate": {
+              "termType": "NamedNode",
+              "value": "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+            },
+            "object": {
+              "termType": "NamedNode",
+              "value": "http://example.com/City"
+            },
+            "graph": {
+              "termType": "NamedNode",
+              "value": "http://example.com/graph"
+            }
+          },
+          "predicate": {
+            "termType": "NamedNode",
+            "value": "http://example.com/author"
+          },
+          "object": {
+            "termType": "Variable",
+            "value": "person"
+          }
+        }
+      ]
+    }
+  ],
+  "type": "query",
+  "prefixes": {
+    "ex": "http://example.com/",
+    "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+  }
+}

--- a/test/parsedQueries/sparql-star-quad-nested-2.json
+++ b/test/parsedQueries/sparql-star-quad-nested-2.json
@@ -1,0 +1,58 @@
+{
+  "queryType": "SELECT",
+  "variables": [
+    {
+      "termType": "Wildcard"
+    }
+  ],
+  "where": [
+    {
+      "type": "bind",
+      "variable": {
+        "termType": "Variable",
+        "value": "spb"
+      },
+      "expression": {
+        "termType": "Quad",
+        "value": "",
+        "subject": {
+          "termType": "Quad",
+          "value": "",
+          "subject": {
+            "termType": "NamedNode",
+            "value": "http://example.com/SaintPetersburg"
+          },
+          "predicate": {
+            "termType": "NamedNode",
+            "value": "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+          },
+          "object": {
+            "termType": "NamedNode",
+            "value": "http://example.com/City"
+          },
+          "graph": {
+            "termType": "NamedNode",
+            "value": "http://example.com/g"
+          }
+        },
+        "predicate": {
+          "termType": "NamedNode",
+          "value": "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+        },
+        "object": {
+          "termType": "NamedNode",
+          "value": "http://example.com/City"
+        },
+        "graph": {
+          "termType": "NamedNode",
+          "value": "http://example.com/g"
+        }
+      }
+    }
+  ],
+  "type": "query",
+  "prefixes": {
+    "ex": "http://example.com/",
+    "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+  }
+}

--- a/test/parsedQueries/sparql-star-quad-nested-3.json
+++ b/test/parsedQueries/sparql-star-quad-nested-3.json
@@ -1,0 +1,73 @@
+{
+  "queryType": "SELECT",
+  "variables": [
+    {
+      "expression": {
+        "termType": "Quad",
+        "value": "",
+        "subject": {
+          "termType": "NamedNode",
+          "value": "http://example.com/Moscow"
+        },
+        "predicate": {
+          "termType": "NamedNode",
+          "value": "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+        },
+        "object": {
+          "termType": "Quad",
+          "value": "",
+          "subject": {
+            "termType": "NamedNode",
+            "value": "http://example.com/Moscow"
+          },
+          "predicate": {
+            "termType": "NamedNode",
+            "value": "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+          },
+          "object": {
+            "termType": "NamedNode",
+            "value": "http://example.com/City"
+          },
+          "graph": {
+            "termType": "NamedNode",
+            "value": "http://example.com/g"
+          }
+        },
+        "graph": {
+          "termType": "NamedNode",
+          "value": "http://example.com/g"
+        }
+      },
+      "variable": {
+        "termType": "Variable",
+        "value": "moscow"
+      }
+    }
+  ],
+  "where": [
+    {
+      "type": "bgp",
+      "triples": [
+        {
+          "subject": {
+            "termType": "NamedNode",
+            "value": "http://example.com/a"
+          },
+          "predicate": {
+            "termType": "NamedNode",
+            "value": "http://example.com/name"
+          },
+          "object": {
+            "termType": "NamedNode",
+            "value": "http://example.com/c"
+          }
+        }
+      ]
+    }
+  ],
+  "type": "query",
+  "prefixes": {
+    "ex": "http://example.com/",
+    "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+  }
+}

--- a/test/parsedQueries/sparql-star-quad-nested.json
+++ b/test/parsedQueries/sparql-star-quad-nested.json
@@ -1,0 +1,148 @@
+{
+  "queryType": "SELECT",
+  "variables": [
+    {
+      "expression": {
+        "termType": "Quad",
+        "value": "",
+        "subject": {
+          "termType": "NamedNode",
+          "value": "http://example.com/Moscow"
+        },
+        "predicate": {
+          "termType": "NamedNode",
+          "value": "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+        },
+        "object": {
+          "termType": "Quad",
+          "value": "",
+          "subject": {
+            "termType": "NamedNode",
+            "value": "http://example.com/Moscow"
+          },
+          "predicate": {
+            "termType": "NamedNode",
+            "value": "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+          },
+          "object": {
+            "termType": "NamedNode",
+            "value": "http://example.com/City"
+          },
+          "graph": {
+            "termType": "NamedNode",
+            "value": "http://example.com/g"
+          }
+        },
+        "graph": {
+          "termType": "NamedNode",
+          "value": "http://example.com/g"
+        }
+      },
+      "variable": {
+        "termType": "Variable",
+        "value": "moscow"
+      }
+    }
+  ],
+  "where": [
+    {
+      "type": "bgp",
+      "triples": [
+        {
+          "subject": {
+            "termType": "Quad",
+            "value": "",
+            "subject": {
+              "termType": "Quad",
+              "value": "",
+              "subject": {
+                "termType": "NamedNode",
+                "value": "http://example.com/Moscow"
+              },
+              "predicate": {
+                "termType": "NamedNode",
+                "value": "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+              },
+              "object": {
+                "termType": "NamedNode",
+                "value": "http://example.com/City"
+              },
+              "graph": {
+                "termType": "NamedNode",
+                "value": "http://example.com/graph"
+              }
+            },
+            "predicate": {
+              "termType": "NamedNode",
+              "value": "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+            },
+            "object": {
+              "termType": "NamedNode",
+              "value": "http://example.com/City"
+            },
+            "graph": {
+              "termType": "NamedNode",
+              "value": "http://example.com/graph"
+            }
+          },
+          "predicate": {
+            "termType": "NamedNode",
+            "value": "http://example.com/author"
+          },
+          "object": {
+            "termType": "Variable",
+            "value": "person"
+          }
+        }
+      ]
+    },
+    {
+      "type": "bind",
+      "variable": {
+        "termType": "Variable",
+        "value": "spb"
+      },
+      "expression": {
+        "termType": "Quad",
+        "value": "",
+        "subject": {
+          "termType": "Quad",
+          "value": "",
+          "subject": {
+            "termType": "NamedNode",
+            "value": "http://example.com/SaintPetersburg"
+          },
+          "predicate": {
+            "termType": "NamedNode",
+            "value": "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+          },
+          "object": {
+            "termType": "NamedNode",
+            "value": "http://example.com/City"
+          },
+          "graph": {
+            "termType": "NamedNode",
+            "value": "http://example.com/g"
+          }
+        },
+        "predicate": {
+          "termType": "NamedNode",
+          "value": "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+        },
+        "object": {
+          "termType": "NamedNode",
+          "value": "http://example.com/City"
+        },
+        "graph": {
+          "termType": "NamedNode",
+          "value": "http://example.com/g"
+        }
+      }
+    }
+  ],
+  "type": "query",
+  "prefixes": {
+    "ex": "http://example.com/",
+    "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+  }
+}

--- a/test/parsedQueries/sparql-star-quad-select-bind.json
+++ b/test/parsedQueries/sparql-star-quad-select-bind.json
@@ -1,0 +1,61 @@
+{
+  "queryType": "SELECT",
+  "variables": [
+    {
+      "termType": "Variable",
+      "value": "spb"
+    },
+    {
+      "expression": {
+        "termType": "Quad",
+        "value": "",
+        "subject": {
+          "termType": "NamedNode",
+          "value": "http://example.com/Moscow"
+        },
+        "predicate": {
+          "termType": "NamedNode",
+          "value": "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+        },
+        "object": {
+          "termType": "NamedNode",
+          "value": "http://example.com/City"
+        },
+        "graph": {
+          "termType": "NamedNode",
+          "value": "http://example.com/g"
+        }
+      },
+      "variable": {
+        "termType": "Variable",
+        "value": "moscow"
+      }
+    }
+  ],
+  "where": [
+    {
+      "type": "bgp",
+      "triples": [
+        {
+          "subject": {
+            "termType": "NamedNode",
+            "value": "http://example.com/a"
+          },
+          "predicate": {
+            "termType": "NamedNode",
+            "value": "http://example.com/name"
+          },
+          "object": {
+            "termType": "NamedNode",
+            "value": "http://example.com/c"
+          }
+        }
+      ]
+    }
+  ],
+  "type": "query",
+  "prefixes": {
+    "ex": "http://example.com/",
+    "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+  }
+}


### PR DESCRIPTION
This PR adapts the parser and generator so they now parse quads in SPARQL* queries.
The syntax for a nested quad is `<< GRAPH g { s p o } >>`
- [x] Added tests
- [x] Updated the parser
- [x] Updated the generator
- [x] Implement nested quads in parser
- [x] Implement nested quads in generator