### PR TITLE
SPARQL* followup: allow variable BIND/projection, constant triple patterns in VALUES()

### DIFF
--- a/lib/sparql.jison
+++ b/lib/sparql.jison
@@ -623,7 +623,8 @@ SubSelect
     ;
 SelectClauseItem
     : VAR -> toVar($1)
-    | '(' (Expression | VarTriple) 'AS' VAR ')' -> expression($2, { variable: toVar($4) })
+    | '(' Expression 'AS' VAR ')' -> expression($2, { variable: toVar($4) })
+    | '(' VarTriple 'AS' VAR ')' -> ensureSparqlStar(expression($2, { variable: toVar($4) }))
     ;
 ConstructQuery
     : 'CONSTRUCT' ConstructTemplate DatasetClause* WhereClause SolutionModifier -> extend({ queryType: 'CONSTRUCT', template: $2 }, groupDatasets($3), $4, $5)
@@ -705,7 +706,7 @@ InlineData
 DataBlockValue
     : iri
     | Literal
-    | ConstTriple
+    | ConstTriple -> ensureSparqlStar($1)
     | 'UNDEF' -> undefined
     ;
 DataBlockValueList
@@ -805,7 +806,8 @@ GraphPatternNotTriples
     | 'GRAPH' (VAR | iri) GroupGraphPattern -> extend($3, { type: 'graph', name: toVar($2) })
     | 'SERVICE' 'SILENT'? (VAR | iri) GroupGraphPattern -> extend($4, { type: 'service', name: toVar($3), silent: !!$2 })
     | 'FILTER' Constraint -> { type: 'filter', expression: $2 }
-    | 'BIND' '(' (Expression | VarTriple) 'AS' VAR ')' -> { type: 'bind', variable: toVar($5), expression: $3 }
+    | 'BIND' '(' Expression 'AS' VAR ')' -> { type: 'bind', variable: toVar($5), expression: $3 }
+    | 'BIND' '(' VarTriple 'AS' VAR ')' -> ensureSparqlStar({ type: 'bind', variable: toVar($5), expression: $3 })
     | ValuesClause
     ;
 Constraint

--- a/lib/sparql.jison
+++ b/lib/sparql.jison
@@ -623,7 +623,7 @@ SubSelect
     ;
 SelectClauseItem
     : VAR -> toVar($1)
-    | '(' (Expression | ConstTriple) 'AS' VAR ')' -> expression($2, { variable: toVar($4) })
+    | '(' (Expression | VarTriple) 'AS' VAR ')' -> expression($2, { variable: toVar($4) })
     ;
 ConstructQuery
     : 'CONSTRUCT' ConstructTemplate DatasetClause* WhereClause SolutionModifier -> extend({ queryType: 'CONSTRUCT', template: $2 }, groupDatasets($3), $4, $5)
@@ -705,6 +705,7 @@ InlineData
 DataBlockValue
     : iri
     | Literal
+    | ConstTriple
     | 'UNDEF' -> undefined
     ;
 DataBlockValueList
@@ -804,7 +805,7 @@ GraphPatternNotTriples
     | 'GRAPH' (VAR | iri) GroupGraphPattern -> extend($3, { type: 'graph', name: toVar($2) })
     | 'SERVICE' 'SILENT'? (VAR | iri) GroupGraphPattern -> extend($4, { type: 'service', name: toVar($3), silent: !!$2 })
     | 'FILTER' Constraint -> { type: 'filter', expression: $2 }
-    | 'BIND' '(' (Expression | ConstTriple) 'AS' VAR ')' -> { type: 'bind', variable: toVar($5), expression: $3 }
+    | 'BIND' '(' (Expression | VarTriple) 'AS' VAR ')' -> { type: 'bind', variable: toVar($5), expression: $3 }
     | ValuesClause
     ;
 Constraint

--- a/queries/sparql-star-bind-var.sparql
+++ b/queries/sparql-star-bind-var.sparql
@@ -1,0 +1,6 @@
+PREFIX ex: <http://example.com/>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+
+SELECT (<< ?a ?b ?c >> as ?x) ?y WHERE {
+    BIND(<< ?s ?p ?o >> as ?y)
+}

--- a/queries/sparql-star-values.sparql
+++ b/queries/sparql-star-values.sparql
@@ -1,0 +1,9 @@
+PREFIX ex: <http://example.com/>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+
+SELECT * WHERE {
+    VALUES ?x {
+        << ex:SaintPetersburg a ex:City >>
+        << ex:a ex:b << ex:Moscow a ex:City >> >>
+    }
+}

--- a/test/parsedQueries/sparql-star-bind-var.json
+++ b/test/parsedQueries/sparql-star-bind-var.json
@@ -1,0 +1,67 @@
+{
+  "queryType": "SELECT",
+  "variables": [
+    {
+      "expression": {
+        "termType": "Quad",
+        "subject": {
+          "termType": "Variable",
+          "value": "a"
+        },
+        "predicate": {
+          "termType": "Variable",
+          "value": "b"
+        },
+        "object": {
+          "termType": "Variable",
+          "value": "c"
+        },
+        "graph": {
+          "termType": "DefaultGraph",
+          "value": ""
+        }
+      },
+      "variable": {
+        "termType": "Variable",
+        "value": "x"
+      }
+    },
+    {
+      "termType": "Variable",
+      "value": "y"
+    }
+  ],
+  "where": [
+    {
+      "type": "bind",
+      "variable": {
+        "termType": "Variable",
+        "value": "y"
+      },
+      "expression": {
+        "termType": "Quad",
+        "subject": {
+          "termType": "Variable",
+          "value": "s"
+        },
+        "predicate": {
+          "termType": "Variable",
+          "value": "p"
+        },
+        "object": {
+          "termType": "Variable",
+          "value": "o"
+        },
+        "graph": {
+          "termType": "DefaultGraph",
+          "value": ""
+        }
+      }
+    }
+  ],
+  "type": "query",
+  "prefixes": {
+    "ex": "http://example.com/",
+    "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+  }
+}

--- a/test/parsedQueries/sparql-star-values.json
+++ b/test/parsedQueries/sparql-star-values.json
@@ -1,0 +1,78 @@
+{
+  "queryType": "SELECT",
+  "variables": [
+    {
+      "termType": "Wildcard",
+      "value": "*"
+    }
+  ],
+  "where": [
+    {
+      "type": "values",
+      "values": [
+        {
+          "?x": {
+            "termType": "Quad",
+            "subject": {
+              "termType": "NamedNode",
+              "value": "http://example.com/SaintPetersburg"
+            },
+            "predicate": {
+              "termType": "NamedNode",
+              "value": "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+            },
+            "object": {
+              "termType": "NamedNode",
+              "value": "http://example.com/City"
+            },
+            "graph": {
+              "termType": "DefaultGraph",
+              "value": ""
+            }
+          }
+        },
+        {
+          "?x": {
+            "termType": "Quad",
+            "subject": {
+              "termType": "NamedNode",
+              "value": "http://example.com/a"
+            },
+            "predicate": {
+              "termType": "NamedNode",
+              "value": "http://example.com/b"
+            },
+            "object": {
+              "termType": "Quad",
+              "subject": {
+                "termType": "NamedNode",
+                "value": "http://example.com/Moscow"
+              },
+              "predicate": {
+                "termType": "NamedNode",
+                "value": "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+              },
+              "object": {
+                "termType": "NamedNode",
+                "value": "http://example.com/City"
+              },
+              "graph": {
+                "termType": "DefaultGraph",
+                "value": ""
+              }
+            },
+            "graph": {
+              "termType": "DefaultGraph",
+              "value": ""
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "type": "query",
+  "prefixes": {
+    "ex": "http://example.com/",
+    "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+  }
+}


### PR DESCRIPTION
According to the paper it should be allowed to use variables inside triple patterns when encountered in `BIND` or projection clauses and constant triple patterns inside `VALUES()`: https://arxiv.org/pdf/1406.3399.pdf

This is also how rdf4j implements it: https://github.com/eclipse/rdf4j/pull/1920/commits/251c979f835af8f9f995bca85621df0d144944a2#diff-c4d16e5e970dd365f5811921f25b6a3aR1027