### PR TITLE
Fix using SELECT (const AS ?var) when aggregates are present

### DIFF
--- a/lib/sparql.jison
+++ b/lib/sparql.jison
@@ -289,16 +289,18 @@
     return [];
   }
 
-  // Get all variables used in an operation
-  function getVariablesFromOperation(operation) {
+  // Get all variables used in an expression
+  function getVariablesFromExpression(expression) {
     const variables = new Set();
-    for (const arg of operation.args) {
-      if (arg.termType === "Variable") {
-        variables.add(arg);
-      } else if (arg.type === "operation") {
-        getVariablesFromOperation(arg).forEach(v => variables.add(v));
+    const visitExpression = function (expr) {
+      if (!expr) { return; }
+      if (expr.termType === "Variable") {
+        variables.add(expr);
+      } else if (expr.type === "operation") {
+        expr.args.forEach(visitExpression);
       }
-    }
+    };
+    visitExpression(expression);
     return variables;
   }
 
@@ -575,7 +577,7 @@ SelectQuery
               throw Error("Projection of ungrouped variable (?" + getExpressionId(selectVar) + ")");
             }
           } else if (getAggregatesOfExpression(selectVar.expression).length === 0) {
-            const usedVars = getVariablesFromOperation(selectVar.expression);
+            const usedVars = getVariablesFromExpression(selectVar.expression);
             for (const usedVar of usedVars) {
               if (!$4.group.map(groupVar => getExpressionId(groupVar)).includes(getExpressionId(usedVar))) {
                 throw Error("Use of ungrouped variable in projection of operation (?" + getExpressionId(usedVar) + ")");

--- a/queries/sparql/group-and-bind.sparql
+++ b/queries/sparql/group-and-bind.sparql
@@ -1,0 +1,6 @@
+PREFIX : <http://www.example.org/>
+SELECT (:foo AS ?foo) (COUNT(?outObject) AS ?out)
+WHERE {
+    ?s :predicate ?outObject
+}
+GROUP BY ?s

--- a/test/parsedQueries/sparql/group-and-bind.json
+++ b/test/parsedQueries/sparql/group-and-bind.json
@@ -1,0 +1,63 @@
+{
+  "queryType": "SELECT",
+  "variables": [
+    {
+      "expression": {
+        "termType": "NamedNode",
+        "value": "http://www.example.org/foo"
+      },
+      "variable": {
+        "termType": "Variable",
+        "value": "foo"
+      }
+    },
+    {
+      "expression": {
+        "expression": {
+          "termType": "Variable",
+          "value": "outObject"
+        },
+        "type": "aggregate",
+        "aggregation": "count",
+        "distinct": false
+      },
+      "variable": {
+        "termType": "Variable",
+        "value": "out"
+      }
+    }
+  ],
+  "where": [
+    {
+      "type": "bgp",
+      "triples": [
+        {
+          "subject": {
+            "termType": "Variable",
+            "value": "s"
+          },
+          "predicate": {
+            "termType": "NamedNode",
+            "value": "http://www.example.org/predicate"
+          },
+          "object": {
+            "termType": "Variable",
+            "value": "outObject"
+          }
+        }
+      ]
+    }
+  ],
+  "group": [
+    {
+      "expression": {
+        "termType": "Variable",
+        "value": "s"
+      }
+    }
+  ],
+  "type": "query",
+  "prefixes": {
+    "": "http://www.example.org/"
+  }
+}


### PR DESCRIPTION
Here is the failing to parse query:
```sparql
PREFIX : <http://www.example.org/>
SELECT (:foo AS ?foo) (COUNT(?outObject) AS ?out)
WHERE {
    ?s :predicate ?outObject
}
GROUP BY ?s
```