### PR TITLE
Replaces n3.DataFactory with rdf-data-factory (closes #121)

### DIFF
--- a/lib/Wildcard.js
+++ b/lib/Wildcard.js
@@ -1,9 +1,7 @@
-const { Term } = require('n3');
 
 // Wildcard constructor
-class Wildcard extends Term {
+class Wildcard {
   constructor() {
-    super('');
     return WILDCARD || this;
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -74,43 +74,14 @@
         "@types/yargs": "^13.0.0"
       }
     },
-    "@rdfjs/data-model": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@rdfjs/data-model/-/data-model-1.1.2.tgz",
-      "integrity": "sha512-pk/G/JLYGaXesoBLvEmoC/ic0H3B79fTyS0Ujjh5YQB2DZW+mn05ZowFFv88rjB9jf7c1XE5XSmf8jzn6U0HHA==",
+    "@types/http-link-header": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@types/http-link-header/-/http-link-header-1.0.2.tgz",
+      "integrity": "sha512-rWvCGMtwx+01LFVpLbSYagloSMgqDwfzLSx9JcwUEkJWo4oDBKihp6X92Ff5tIS4VE5ojV4wH6iMnAnr/TZhhg==",
       "dev": true,
       "requires": {
-        "@types/rdf-js": "^2.0.1"
-      },
-      "dependencies": {
-        "@types/rdf-js": {
-          "version": "2.0.12",
-          "resolved": "https://registry.npmjs.org/@types/rdf-js/-/rdf-js-2.0.12.tgz",
-          "integrity": "sha512-NBzHFHp2vHOJkPlSqzsOrkEsD9grKn+PdFjZieIw59pc0FlRG6WEQAjQZvHzFxJlYzC6ZDCFyTA1wBvUnnzUQw==",
-          "dev": true,
-          "requires": {
-            "@types/node": "*"
-          }
-        }
+        "@types/node": "*"
       }
-    },
-    "@types/color-name": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
-      "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
-      "dev": true
-    },
-    "@types/http-link-header": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@types/http-link-header/-/http-link-header-1.0.1.tgz",
-      "integrity": "sha512-5h+Pqs4EHoMkY/fLva7XsYmh9IVQghQ6uWWil1FGCNI0WqjhI4g20doYsbT4kJ/G3GkAlQca4AIc9OexdUnzkg==",
-      "dev": true
-    },
-    "@types/isomorphic-fetch": {
-      "version": "0.0.35",
-      "resolved": "https://registry.npmjs.org/@types/isomorphic-fetch/-/isomorphic-fetch-0.0.35.tgz",
-      "integrity": "sha512-DaZNUvLDCAnCTjgwxgiL1eQdxIKEpNLOlTNtAgnZc50bG2copGhRrFN9/PxPBuJe+tZVLCbQ7ls0xveXVRPkvw==",
-      "dev": true
     },
     "@types/istanbul-lib-coverage": {
       "version": "2.0.3",
@@ -159,9 +130,9 @@
       "dev": true
     },
     "@types/n3": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/@types/n3/-/n3-1.4.3.tgz",
-      "integrity": "sha512-NJ6GKZDE/6Q9iF9Zg+c89WHLK6VXIyVPfvPw6Z8/17ssk1Vx944XcAn0ZmPlRnvUXlGCg63NmMGzB20X46cs4A==",
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/@types/n3/-/n3-1.4.4.tgz",
+      "integrity": "sha512-xsWfwyDh0uAH0CXvwqe9vb2UEDafMjRez/pB7yZwbWpd9Olw2wdxaL32FtdHjmmFE6b9i+j249JfRyZnvWkoqg==",
       "dev": true,
       "requires": {
         "@types/node": "*",
@@ -169,16 +140,14 @@
       }
     },
     "@types/node": {
-      "version": "14.0.27",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.27.tgz",
-      "integrity": "sha512-kVrqXhbclHNHGu9ztnAwSncIgJv/FaxmzXJvGXNdcCpV1b8u1/Mi6z6m0vwy0LzKeXFTPLH0NzwmoJ3fNCIq0g==",
-      "dev": true
+      "version": "14.14.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.6.tgz",
+      "integrity": "sha512-6QlRuqsQ/Ox/aJEQWBEJG7A9+u7oSYl3mem/K8IzxXG/kAGbV1YPD9Bg9Zw3vyxC/YP+zONKwy8hGkSt1jxFMw=="
     },
     "@types/rdf-js": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@types/rdf-js/-/rdf-js-3.0.3.tgz",
-      "integrity": "sha512-1dvodNHh/YpLovHA/b046Nu+xERVt0KcYJFQH1A8S4ZcMj+stYtx4ypXw0X2/oatbREUo4JW+cjoBll3CVtwSQ==",
-      "dev": true,
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@types/rdf-js/-/rdf-js-4.0.0.tgz",
+      "integrity": "sha512-2uaR7ks0380MqzUWGOPOOk9yZIr/6MOaCcaj3ntKgd2PqNocgi8j5kSHIJTDe+5ABtTHqKMSE0v0UqrsT8ibgQ==",
       "requires": {
         "@types/node": "*"
       }
@@ -199,9 +168,9 @@
       "dev": true
     },
     "@types/yargs": {
-      "version": "13.0.9",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.9.tgz",
-      "integrity": "sha512-xrvhZ4DZewMDhoH1utLtOAwYQy60eYFoXeje30TzM3VOvQlBwQaEpKFq5m34k1wOw2AKIi2pwtiAjdmhvlBUzg==",
+      "version": "13.0.11",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.11.tgz",
+      "integrity": "sha512-NRqD6T4gktUrDi1o1wLH3EKC1o2caCr7/wR87ODcbVITQF106OM3sFN92ysZ++wqelOd1CTzatnOBRDYYG6wGQ==",
       "dev": true,
       "requires": {
         "@types/yargs-parser": "*"
@@ -459,6 +428,16 @@
         "unset-value": "^1.0.0"
       }
     },
+    "call-bind": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.0.tgz",
+      "integrity": "sha512-AEXsYIyyDY3MCzbwdhzG3Jx1R0J2wetQyUynn6dYHAO+bg8l1k7jwZtRv4ryryFs7EP+NDlikJlVe59jr0cM2w==",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.1",
+        "get-intrinsic": "^1.0.0"
+      }
+    },
     "callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -472,9 +451,9 @@
       "dev": true
     },
     "canonicalize": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/canonicalize/-/canonicalize-1.0.1.tgz",
-      "integrity": "sha512-N3cmB3QLhS5TJ5smKFf1w42rJXWe6C1qP01z4dxJiI5v269buii4fLHWETDyf7yEd0azGLNC63VxNMiPd2u0Cg==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/canonicalize/-/canonicalize-1.0.3.tgz",
+      "integrity": "sha512-QWAGweNicWIXzcl7skvUZQ/ArdecS8fOeudnjIU0LYqSdTOSBSap+0VPMas4u11cW3a9sN5AN/aJHQUGfdWLCw==",
       "dev": true
     },
     "chalk": {
@@ -671,6 +650,15 @@
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true
     },
+    "cross-fetch": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.0.6.tgz",
+      "integrity": "sha512-KBPUbqgFjzWlVcURG+Svp9TlhA5uliYtiNx/0r8nv0pdypeQCRJ9IaSIc3q/x3q8t3F75cHuwxVql1HFGHCNJQ==",
+      "dev": true,
+      "requires": {
+        "node-fetch": "2.6.1"
+      }
+    },
     "cross-spawn": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
@@ -777,32 +765,37 @@
       "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
       "dev": true
     },
-    "encoding": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
-      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
-      "dev": true,
-      "requires": {
-        "iconv-lite": "^0.6.2"
-      }
-    },
     "es-abstract": {
-      "version": "1.17.6",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.6.tgz",
-      "integrity": "sha512-Fr89bON3WFyUi5EvAeI48QTWX0AyekGgLA8H+c+7fbfCkJwRWRMLd8CQedNEyJuoYYhmtEqY92pgte1FAhBlhw==",
+      "version": "1.17.7",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.7.tgz",
+      "integrity": "sha512-VBl/gnfcJ7OercKA9MVaegWsBHFjV492syMudcnQZvt/Dw8ezpcOHYZXa/J96O8vx+g4x65YKhxOwDUh63aS5g==",
       "dev": true,
       "requires": {
         "es-to-primitive": "^1.2.1",
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
         "has-symbols": "^1.0.1",
-        "is-callable": "^1.2.0",
-        "is-regex": "^1.1.0",
-        "object-inspect": "^1.7.0",
+        "is-callable": "^1.2.2",
+        "is-regex": "^1.1.1",
+        "object-inspect": "^1.8.0",
         "object-keys": "^1.1.1",
-        "object.assign": "^4.1.0",
+        "object.assign": "^4.1.1",
         "string.prototype.trimend": "^1.0.1",
         "string.prototype.trimstart": "^1.0.1"
+      },
+      "dependencies": {
+        "object.assign": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
+          "integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+          "dev": true,
+          "requires": {
+            "call-bind": "^1.0.0",
+            "define-properties": "^1.1.3",
+            "has-symbols": "^1.0.1",
+            "object-keys": "^1.1.1"
+          }
+        }
       }
     },
     "es-to-primitive": {
@@ -1032,9 +1025,9 @@
       }
     },
     "flat": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/flat/-/flat-4.1.0.tgz",
-      "integrity": "sha512-Px/TiLIznH7gEDlPXcUD4KnBusa6kR6ayRUVcnEAbreRIuhkqow/mun59BuRXwoYk7ZQOLW1ZM05ilIvK38hFw==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/flat/-/flat-4.1.1.tgz",
+      "integrity": "sha512-FmTtBsHskrU6FJ2VxCnsDb84wu9zhmO3cUX2kGFb5tuwhfXxGciiT0oRY+cck35QmG+NmGh5eLz6lLCpWTqwpA==",
       "dev": true,
       "requires": {
         "is-buffer": "~2.0.3"
@@ -1087,6 +1080,17 @@
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
       "dev": true
+    },
+    "get-intrinsic": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.0.1.tgz",
+      "integrity": "sha512-ZnWP+AmS1VUaLgTRy47+zKtjTxz+0xMpx3I52i+aalBK1QP19ggLF3Db89KJX7kjfOfP2eoa01qc++GwPgufPg==",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.1"
+      }
     },
     "get-value": {
       "version": "2.0.6",
@@ -1189,19 +1193,10 @@
       "dev": true
     },
     "http-link-header": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/http-link-header/-/http-link-header-1.0.2.tgz",
-      "integrity": "sha512-z6YOZ8ZEnejkcCWlGZzYXNa6i+ZaTfiTg3WhlV/YvnNya3W/RbX1bMVUMTuCrg/DrtTCQxaFCkXCz4FtLpcebg==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/http-link-header/-/http-link-header-1.0.3.tgz",
+      "integrity": "sha512-nARK1wSKoBBrtcoESlHBx36c1Ln/gnbNQi1eB6MeTUefJIT3NvUOsV15bClga0k38f0q/kN5xxrGSDS3EFnm9w==",
       "dev": true
-    },
-    "iconv-lite": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.2.tgz",
-      "integrity": "sha512-2y91h5OpQlolefMPmUlivelittSWy0rP+oYVpn6A7GwVHNE8AWzoYOBNmlwks3LobaJxgHCYZAnyNo2GgpNRNQ==",
-      "dev": true,
-      "requires": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
-      }
     },
     "inflight": {
       "version": "1.0.6",
@@ -1255,9 +1250,9 @@
       "dev": true
     },
     "is-callable": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.0.tgz",
-      "integrity": "sha512-pyVD9AaGLxtg6srb2Ng6ynWJqkHU9bEM087AKck0w8QwDarTfNcpIYoU8x8Hv2Icm8u6kFJM18Dag8lyqGkviw==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.2.tgz",
+      "integrity": "sha512-dnMqspv5nU3LoewK2N/y7KLtxtakvTuaCsU9FU50/QDmdbHNy/4/JuRtMHqRU22o3q+W89YQndQEeCVwK+3qrA==",
       "dev": true
     },
     "is-data-descriptor": {
@@ -1332,6 +1327,12 @@
         "is-extglob": "^2.1.1"
       }
     },
+    "is-negative-zero": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.0.tgz",
+      "integrity": "sha1-lVOxIbD6wohp2p7UWeIMdUN4hGE=",
+      "dev": true
+    },
     "is-number": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
@@ -1362,19 +1363,13 @@
       }
     },
     "is-regex": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.0.tgz",
-      "integrity": "sha512-iI97M8KTWID2la5uYXlkbSDQIg4F6o1sYboZKKTDpnDQMLtUL86zxhgDet3Q2SriaYsyGqZ6Mn2SjbRKeLHdqw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.1.tgz",
+      "integrity": "sha512-1+QkEcxiLlB7VEyFtyBg94e08OAsvq7FUBgApTq/w2ymCLyKJgDPsybBENVtA7XCQEgEXxKPonG+mvYRxh/LIg==",
       "dev": true,
       "requires": {
         "has-symbols": "^1.0.1"
       }
-    },
-    "is-stream": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
-      "dev": true
     },
     "is-symbol": {
       "version": "1.0.3",
@@ -1408,16 +1403,6 @@
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
       "dev": true
-    },
-    "isomorphic-fetch": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
-      "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
-      "dev": true,
-      "requires": {
-        "node-fetch": "^1.0.1",
-        "whatwg-fetch": ">=0.10.0"
-      }
     },
     "jest-diff": {
       "version": "24.9.0",
@@ -1537,41 +1522,40 @@
       "dev": true
     },
     "jsonld-context-parser": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/jsonld-context-parser/-/jsonld-context-parser-2.0.2.tgz",
-      "integrity": "sha512-IjQi26E+5ESS85MkcLsYo9gV93oJSOvQ/deHxKspaeHOmRiPyRRaGAk86DjuQc6c0hdp3OKGvDDsy3wi8znsqg==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/jsonld-context-parser/-/jsonld-context-parser-2.1.1.tgz",
+      "integrity": "sha512-7yKhnwFaiCnDPUZYQuAWyT0zZBfOKZDyjtqFVNbXrYRkboU+m55UsastsfXbo7qNroTGdFiEyxHEHDEfBC0P4Q==",
       "dev": true,
       "requires": {
         "@types/http-link-header": "^1.0.1",
-        "@types/isomorphic-fetch": "^0.0.35",
         "@types/node": "^13.1.0",
         "canonicalize": "^1.0.1",
+        "cross-fetch": "^3.0.6",
         "http-link-header": "^1.0.2",
-        "isomorphic-fetch": "^2.2.1",
         "relative-to-absolute-iri": "^1.0.5"
       },
       "dependencies": {
         "@types/node": {
-          "version": "13.13.15",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.15.tgz",
-          "integrity": "sha512-kwbcs0jySLxzLsa2nWUAGOd/s21WU1jebrEdtzhsj1D4Yps1EOuyI1Qcu+FD56dL7NRNIJtDDjcqIG22NwkgLw==",
+          "version": "13.13.30",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.30.tgz",
+          "integrity": "sha512-HmqFpNzp3TSELxU/bUuRK+xzarVOAsR00hzcvM0TXrMlt/+wcSLa5q6YhTb6/cA6wqDCZLDcfd8fSL95x5h7AA==",
           "dev": true
         }
       }
     },
     "jsonld-streaming-parser": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/jsonld-streaming-parser/-/jsonld-streaming-parser-2.0.2.tgz",
-      "integrity": "sha512-h4cK+PQMvOHd+UqgAFpKBmt5LWYoQMQLu9PP7YsRP7rnSJbU/EfJFcJFG6/sdtZslQ6dlNwOvfHbjQ9clzZPzg==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/jsonld-streaming-parser/-/jsonld-streaming-parser-2.1.1.tgz",
+      "integrity": "sha512-QEOV+cMMBZCz30XkkX07/ziyETFDZz1fGlrKpXmnuj/iw9yN2PbvwTVCz4Snk/sy1V2sBVuF5L/ubd2XXerY8w==",
       "dev": true,
       "requires": {
-        "@rdfjs/data-model": "^1.1.2",
         "@types/http-link-header": "^1.0.1",
-        "@types/rdf-js": "^3.0.0",
+        "@types/rdf-js": "*",
         "canonicalize": "^1.0.1",
         "http-link-header": "^1.0.2",
         "jsonld-context-parser": "^2.0.1",
-        "jsonparse": "^1.3.1"
+        "jsonparse": "^1.3.1",
+        "rdf-data-factory": "^1.0.2"
       }
     },
     "jsonlint": {
@@ -1613,9 +1597,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.19",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
-      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
+      "version": "4.17.20",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
       "dev": true
     },
     "lodash.uniqwith": {
@@ -1789,11 +1773,26 @@
       "dev": true
     },
     "n3": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/n3/-/n3-1.6.0.tgz",
-      "integrity": "sha512-wqnhi/NhD/O4Tt/SK1dgiC1hLJWG7nwmvh5n7wFDKlxI8QlmvyxmY1b9deVh1D08GCZJtDYvwdmJ5EdZXgp9bg==",
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/n3/-/n3-1.6.3.tgz",
+      "integrity": "sha512-dN+8pLw2h1H1WQTW9VR3T16tHPDYdQP+YKXzbcpBCMCb9ZkksUyoVRRdtFGl3vosdET+NIB5eiIgth+4Vit6Yw==",
+      "dev": true,
       "requires": {
-        "queue-microtask": "^1.1.2"
+        "queue-microtask": "^1.1.2",
+        "readable-stream": "^3.6.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
       }
     },
     "nanomatch": {
@@ -1826,14 +1825,10 @@
       }
     },
     "node-fetch": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
-      "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
-      "dev": true,
-      "requires": {
-        "encoding": "^0.1.11",
-        "is-stream": "^1.0.1"
-      }
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
+      "dev": true
     },
     "nomnom": {
       "version": "1.5.2",
@@ -2056,113 +2051,121 @@
       "dev": true
     },
     "queue-microtask": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.1.4.tgz",
-      "integrity": "sha512-eY/4Obve9cE5FK8YvC1cJsm5cr7XvAurul8UtBDJ2PR1p5NmAwHtvAt5ftcLtwYRCUKNhxCneZZlxmUDFoSeKA=="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.0.tgz",
+      "integrity": "sha512-J95OVUiS4b8qqmpqhCodN8yPpHG2mpZUPQ8tDGyIY0VhM+kBHszOuvsMJVGNQ1OH2BnTFbqz45i+2jGpDw9H0w==",
+      "dev": true
+    },
+    "rdf-data-factory": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/rdf-data-factory/-/rdf-data-factory-1.0.4.tgz",
+      "integrity": "sha512-ZIIwEkLcV7cTc+atvQFzAETFVRHz1BRe/MhdkZqYse8vxskErj8/bF/Ittc3B5c0GTyw6O3jVF2V7xBRGyRoSQ==",
+      "requires": {
+        "@types/rdf-js": "*"
+      }
     },
     "rdf-isomorphic": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/rdf-isomorphic/-/rdf-isomorphic-1.1.0.tgz",
-      "integrity": "sha512-E4E3RJJ0RBBCDGJ6cx7httfnV0Z2xcdF81epe581xSvPsCe42qWYysZ6DKTkBTrmMjNeScNnDkjubLS5RSODtw==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/rdf-isomorphic/-/rdf-isomorphic-1.2.0.tgz",
+      "integrity": "sha512-Dq+iuWrVuK7q3P4/nychbWhRJ1M5yMAekNJN8f5pjarE8SH9Duy/R0JopVF0I0Q2w0poZlsVKKIBpeG+AdOSAw==",
       "dev": true,
       "requires": {
-        "rdf-string": "^1.3.1",
-        "rdf-terms": "^1.4.0"
+        "rdf-string": "^1.5.0",
+        "rdf-terms": "^1.6.2"
       }
     },
     "rdf-literal": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/rdf-literal/-/rdf-literal-1.1.1.tgz",
-      "integrity": "sha512-zYelIUgvwifeq2aFfTYlv+SoxZbSjdKw+I4ulZ5ECil8FTh2+ufHiR9P7T61KnVyo8BqBhyeHBR4UvA++PWozA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/rdf-literal/-/rdf-literal-1.2.0.tgz",
+      "integrity": "sha512-N7nyfp/xzoiUuJt0xZ80BvBGkCPwWejgVDkCxWDSuooXKSows4ToW+KouYkMHLcoFzGg1Rlw2lk6btjMJg5aSA==",
       "dev": true,
       "requires": {
-        "@rdfjs/data-model": "^1.1.1",
-        "@types/rdf-js": "^3.0.0"
+        "@types/rdf-js": "*",
+        "rdf-data-factory": "^1.0.1"
       }
     },
     "rdf-object": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/rdf-object/-/rdf-object-1.2.0.tgz",
-      "integrity": "sha512-vYfJiKd5BmMmCqJ/linkJWhMfR0MRynt3uCupjfG1lDqAM9IKBtfIt7rMTCBEOcbNWEIg+2iZ3ACvFqPRcHcNQ==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/rdf-object/-/rdf-object-1.4.0.tgz",
+      "integrity": "sha512-iRba1XITW3msfi1XCF1vZKrfIGUQdUqWg+FXTeFKbW0sjZKe0Qm3wOzDsL9+dT+goVidYnqDkPhp48Ej2IH02A==",
       "dev": true,
       "requires": {
-        "@rdfjs/data-model": "^1.1.2",
-        "jsonld-context-parser": "^2.0.0",
-        "rdf-string": "^1.3.1",
+        "jsonld-context-parser": "^2.0.2",
+        "rdf-data-factory": "^1.0.3",
+        "rdf-string": "^1.5.0",
         "streamify-array": "^1.0.1"
       }
     },
     "rdf-quad": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/rdf-quad/-/rdf-quad-1.4.0.tgz",
-      "integrity": "sha512-xChDvhK2zb4/aCg8P668CWTn4TEhscefg/E1s+Qu61sZ/hKct/WQn0wuHim8H+MFrzZ7fFN7Gh7aamPgm/QSwA==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/rdf-quad/-/rdf-quad-1.5.0.tgz",
+      "integrity": "sha512-LnCYx8XbRVW1wr6UiZPSy2Tv7bXAtEwuyck/68dANhFu8VMnGS+QfUNP3b9YI6p4Bfd/fyDx5E3x81IxGV6BzA==",
       "dev": true,
       "requires": {
-        "@rdfjs/data-model": "^1.1.1",
-        "rdf-literal": "^1.0.0",
-        "rdf-string": "^1.3.1"
+        "rdf-data-factory": "^1.0.1",
+        "rdf-literal": "^1.2.0",
+        "rdf-string": "^1.5.0"
       }
     },
     "rdf-string": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/rdf-string/-/rdf-string-1.4.2.tgz",
-      "integrity": "sha512-74yYjS0W4N3nYDGbXBZrNsqDmhBTjqChTETO9heC2G2M3iMYaIPtEfUikNsBWUj4+4bIKyqL7vAntWBTfJpFFA==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/rdf-string/-/rdf-string-1.5.0.tgz",
+      "integrity": "sha512-3TEJuDIKUADgZrfcZG+zAN4GfVA1Ei2sKA7Z7QVHkAE36wWoRGPJbGihPQMldgzvy9lG2nzZU+CXz+6oGSQNsQ==",
       "dev": true,
       "requires": {
-        "@rdfjs/data-model": "^1.1.1"
+        "rdf-data-factory": "^1.0.0"
       }
     },
     "rdf-terms": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/rdf-terms/-/rdf-terms-1.5.1.tgz",
-      "integrity": "sha512-dDhpUYxTAOWKT3Ln93A5k5UB5SftG8bPAzeZEjGeP4e7eboMhITUTDks8HDmUt9X1P+HpfnY/o6VSTSpf3Advw==",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/rdf-terms/-/rdf-terms-1.6.2.tgz",
+      "integrity": "sha512-dASpdYHYLEwzN9iSymJie1WUj6VHXy1By8Am4g2rJlhTfVvNitsJpDY+A3X2QehlGhCaWjHMzXS4q/JKNPI80A==",
       "dev": true,
       "requires": {
-        "@rdfjs/data-model": "^1.1.1",
-        "lodash.uniqwith": "^4.5.0"
+        "lodash.uniqwith": "^4.5.0",
+        "rdf-data-factory": "^1.0.1"
       }
     },
     "rdf-test-suite": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/rdf-test-suite/-/rdf-test-suite-1.13.1.tgz",
-      "integrity": "sha512-O+j3BimspDQcX/x+cMnFcp6KV06832cfLn3+GyQ25jBxt6LXxvJSZvoHRopxL9lRhTuRPYorsjt0UriY2D5+6A==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/rdf-test-suite/-/rdf-test-suite-1.16.0.tgz",
+      "integrity": "sha512-Y/rAZMJQV9xSGlmG55cJ1v9/y0Bd+uYQCO3qFKe9LKqXK/3zCrvRLSV8Wr5ag9vfZsOCYlmXZwk75am3YayPzg==",
       "dev": true,
       "requires": {
-        "@rdfjs/data-model": "^1.1.2",
         "@types/json-stable-stringify": "^1.0.32",
         "@types/log-symbols": "^3.0.0",
         "@types/minimist": "^1.2.0",
-        "@types/n3": "^1.1.6",
-        "@types/rdf-js": "^3.0.0",
+        "@types/n3": "^1.4.4",
+        "@types/rdf-js": "*",
         "@types/sax": "^1.0.1",
         "arrayify-stream": "^1.0.0",
-        "isomorphic-fetch": "^2.2.1",
+        "cross-fetch": "^3.0.6",
         "json-stable-stringify": "^1.0.1",
-        "jsonld-streaming-parser": "^2.0.0",
+        "jsonld-streaming-parser": "^2.1.0",
         "log-symbols": "^4.0.0",
         "minimist": "^1.2.0",
         "n3": "^1.1.1",
-        "rdf-isomorphic": "^1.1.0",
-        "rdf-literal": "^1.0.0",
-        "rdf-object": "^1.1.0",
-        "rdf-quad": "^1.3.0",
-        "rdf-string": "^1.3.1",
-        "rdf-terms": "^1.4.0",
-        "rdfxml-streaming-parser": "^1.3.4",
-        "relative-to-absolute-iri": "^1.0.5",
-        "sparqljson-parse": "^1.5.0",
-        "sparqlxml-parse": "^1.2.1",
+        "rdf-data-factory": "^1.0.3",
+        "rdf-isomorphic": "^1.2.0",
+        "rdf-literal": "^1.2.0",
+        "rdf-object": "^1.3.0",
+        "rdf-quad": "^1.5.0",
+        "rdf-string": "^1.5.0",
+        "rdf-terms": "^1.6.2",
+        "rdfxml-streaming-parser": "^1.4.0",
+        "relative-to-absolute-iri": "^1.0.6",
+        "sparqljson-parse": "^1.6.0",
+        "sparqlxml-parse": "^1.4.0",
         "stream-to-string": "^1.1.0",
         "streamify-string": "^1.0.1"
       },
       "dependencies": {
         "ansi-styles": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
           "dev": true,
           "requires": {
-            "@types/color-name": "^1.1.1",
             "color-convert": "^2.0.1"
           }
         },
@@ -2207,9 +2210,9 @@
           }
         },
         "supports-color": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
           "dev": true,
           "requires": {
             "has-flag": "^4.0.0"
@@ -2218,12 +2221,13 @@
       }
     },
     "rdfxml-streaming-parser": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/rdfxml-streaming-parser/-/rdfxml-streaming-parser-1.3.6.tgz",
-      "integrity": "sha512-t9uqmCiPjmMFMXQ3Va2rc4ePElhze63EUmXVLA05s40NQEvphj8I8Kl1qODBwHnxocdoc1yVQRsC6hVJAPHvPQ==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/rdfxml-streaming-parser/-/rdfxml-streaming-parser-1.4.0.tgz",
+      "integrity": "sha512-/FKDCq4tuSWz8PZaaPxqIQpenEvRR3Gsqllqg4VmdPFN6WiWfbaD244cKASfXfQHt9Bw7tLsLHsmtA1isIPBCg==",
       "dev": true,
       "requires": {
-        "@rdfjs/data-model": "^1.1.2",
+        "@types/rdf-js": "*",
+        "rdf-data-factory": "^1.0.2",
         "relative-to-absolute-iri": "^1.0.0",
         "sax": "^1.2.4"
       }
@@ -2324,12 +2328,6 @@
       "requires": {
         "ret": "~0.1.10"
       }
-    },
-    "safer-buffer": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true
     },
     "sax": {
       "version": "1.2.4",
@@ -2542,51 +2540,42 @@
       "dev": true
     },
     "sparqljson-parse": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/sparqljson-parse/-/sparqljson-parse-1.5.2.tgz",
-      "integrity": "sha512-VnYzLsiha3Byb7iKr4qbwsztF7cjZFDEnJg2Z2fSbVlUOa4Pwk4cHem6SnFDBWRrOtu/N98v9/JMVRi6bQYqew==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/sparqljson-parse/-/sparqljson-parse-1.6.0.tgz",
+      "integrity": "sha512-alIiURVr3AXIGU6fjuh5k6fwINwGKBQu5QnN9TEpoyIRvukKxZLQE07AHsw/Wxhkxico81tPf8nJTx7H1ira5A==",
       "dev": true,
       "requires": {
-        "@rdfjs/data-model": "^1.1.1",
         "@types/node": "^13.1.0",
-        "@types/rdf-js": "^3.0.0",
-        "JSONStream": "^1.3.3"
+        "@types/rdf-js": "*",
+        "JSONStream": "^1.3.3",
+        "rdf-data-factory": "^1.0.2"
       },
       "dependencies": {
         "@types/node": {
-          "version": "13.13.15",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.15.tgz",
-          "integrity": "sha512-kwbcs0jySLxzLsa2nWUAGOd/s21WU1jebrEdtzhsj1D4Yps1EOuyI1Qcu+FD56dL7NRNIJtDDjcqIG22NwkgLw==",
+          "version": "13.13.30",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.30.tgz",
+          "integrity": "sha512-HmqFpNzp3TSELxU/bUuRK+xzarVOAsR00hzcvM0TXrMlt/+wcSLa5q6YhTb6/cA6wqDCZLDcfd8fSL95x5h7AA==",
           "dev": true
         }
       }
     },
     "sparqlxml-parse": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/sparqlxml-parse/-/sparqlxml-parse-1.2.2.tgz",
-      "integrity": "sha512-xFN+S97DRI9jrlFsOntB8rmtEAJeTUAyRCquibiLCbE+z63iw1tFdM9NhrphrPey1+EH75vh9AjycXwDD6nEIw==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/sparqlxml-parse/-/sparqlxml-parse-1.4.0.tgz",
+      "integrity": "sha512-hKYsRw+KHIF4QXpMtybCSkfVhoQmTdUrUe5WkYnlyyw+3aeskIDnd97TPQi7MNSok2aim02osqkHvWQFNGXm3A==",
       "dev": true,
       "requires": {
-        "@rdfjs/data-model": "^1.1.1",
-        "@types/node": "^10.12.18",
-        "@types/rdf-js": "^2.0.2",
+        "@types/node": "^13.1.0",
+        "@types/rdf-js": "*",
+        "rdf-data-factory": "^1.0.2",
         "sax-stream": "^1.2.3"
       },
       "dependencies": {
         "@types/node": {
-          "version": "10.17.28",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.28.tgz",
-          "integrity": "sha512-dzjES1Egb4c1a89C7lKwQh8pwjYmlOAG9dW1pBgxEk57tMrLnssOfEthz8kdkNaBd7lIqQx7APm5+mZ619IiCQ==",
+          "version": "13.13.30",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.30.tgz",
+          "integrity": "sha512-HmqFpNzp3TSELxU/bUuRK+xzarVOAsR00hzcvM0TXrMlt/+wcSLa5q6YhTb6/cA6wqDCZLDcfd8fSL95x5h7AA==",
           "dev": true
-        },
-        "@types/rdf-js": {
-          "version": "2.0.12",
-          "resolved": "https://registry.npmjs.org/@types/rdf-js/-/rdf-js-2.0.12.tgz",
-          "integrity": "sha512-NBzHFHp2vHOJkPlSqzsOrkEsD9grKn+PdFjZieIw59pc0FlRG6WEQAjQZvHzFxJlYzC6ZDCFyTA1wBvUnnzUQw==",
-          "dev": true,
-          "requires": {
-            "@types/node": "*"
-          }
         }
       }
     },
@@ -2674,23 +2663,91 @@
       }
     },
     "string.prototype.trimend": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.1.tgz",
-      "integrity": "sha512-LRPxFUaTtpqYsTeNKaFOw3R4bxIzWOnbQ837QfBylo8jIxtcbK/A/sMV7Q+OAV/vWo+7s25pOE10KYSjaSO06g==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.2.tgz",
+      "integrity": "sha512-8oAG/hi14Z4nOVP0z6mdiVZ/wqjDtWSLygMigTzAb+7aPEDTleeFf+WrF+alzecxIRkckkJVn+dTlwzJXORATw==",
       "dev": true,
       "requires": {
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.17.5"
+        "es-abstract": "^1.18.0-next.1"
+      },
+      "dependencies": {
+        "es-abstract": {
+          "version": "1.18.0-next.1",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.1.tgz",
+          "integrity": "sha512-I4UGspA0wpZXWENrdA0uHbnhte683t3qT/1VFH9aX2dA5PPSf6QW5HHXf5HImaqPmjXaVeVk4RGWnaylmV7uAA==",
+          "dev": true,
+          "requires": {
+            "es-to-primitive": "^1.2.1",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.1",
+            "is-callable": "^1.2.2",
+            "is-negative-zero": "^2.0.0",
+            "is-regex": "^1.1.1",
+            "object-inspect": "^1.8.0",
+            "object-keys": "^1.1.1",
+            "object.assign": "^4.1.1",
+            "string.prototype.trimend": "^1.0.1",
+            "string.prototype.trimstart": "^1.0.1"
+          }
+        },
+        "object.assign": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
+          "integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+          "dev": true,
+          "requires": {
+            "call-bind": "^1.0.0",
+            "define-properties": "^1.1.3",
+            "has-symbols": "^1.0.1",
+            "object-keys": "^1.1.1"
+          }
+        }
       }
     },
     "string.prototype.trimstart": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.1.tgz",
-      "integrity": "sha512-XxZn+QpvrBI1FOcg6dIpxUPgWCPuNXvMD72aaRaUQv1eD4e/Qy8i/hFTe0BUmD60p/QA6bh1avmuPTfNjqVWRw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.2.tgz",
+      "integrity": "sha512-7F6CdBTl5zyu30BJFdzSTlSlLPwODC23Od+iLoVH8X6+3fvDPPuBVVj9iaB1GOsSTSIgVfsfm27R2FGrAPznWg==",
       "dev": true,
       "requires": {
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.17.5"
+        "es-abstract": "^1.18.0-next.1"
+      },
+      "dependencies": {
+        "es-abstract": {
+          "version": "1.18.0-next.1",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.1.tgz",
+          "integrity": "sha512-I4UGspA0wpZXWENrdA0uHbnhte683t3qT/1VFH9aX2dA5PPSf6QW5HHXf5HImaqPmjXaVeVk4RGWnaylmV7uAA==",
+          "dev": true,
+          "requires": {
+            "es-to-primitive": "^1.2.1",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.1",
+            "is-callable": "^1.2.2",
+            "is-negative-zero": "^2.0.0",
+            "is-regex": "^1.1.1",
+            "object-inspect": "^1.8.0",
+            "object-keys": "^1.1.1",
+            "object.assign": "^4.1.1",
+            "string.prototype.trimend": "^1.0.1",
+            "string.prototype.trimstart": "^1.0.1"
+          }
+        },
+        "object.assign": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
+          "integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+          "dev": true,
+          "requires": {
+            "call-bind": "^1.0.0",
+            "define-properties": "^1.1.3",
+            "has-symbols": "^1.0.1",
+            "object-keys": "^1.1.1"
+          }
+        }
       }
     },
     "string_decoder": {
@@ -2862,12 +2919,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-      "dev": true
-    },
-    "whatwg-fetch": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.2.0.tgz",
-      "integrity": "sha512-SdGPoQMMnzVYThUbSrEvqTlkvC1Ux27NehaJ/GUHBfNrh5Mjg+1/uRyFMwVnxO2MrikMWvWAqUGgQOfVU4hT7w==",
       "dev": true
     },
     "which": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "node": ">=8.0"
   },
   "dependencies": {
-    "n3": "^1.6.0"
+    "rdf-data-factory": "^1.0.4"
   },
   "devDependencies": {
     "expect": "^24.8.0",

--- a/sparql.js
+++ b/sparql.js
@@ -1,7 +1,7 @@
 var Parser = require('./lib/SparqlParser').Parser;
 var Generator = require('./lib/SparqlGenerator');
 var Wildcard = require("./lib/Wildcard").Wildcard;
-var N3 = require('n3');
+var { DataFactory } = require('rdf-data-factory');
 
 module.exports = {
   /**
@@ -25,7 +25,7 @@ module.exports = {
     parser.parse = function () {
       Parser.base = baseIRI || '';
       Parser.prefixes = Object.create(prefixesCopy);
-      Parser.factory = factory || N3.DataFactory;
+      Parser.factory = factory || new DataFactory();
       Parser.sparqlStar = Boolean(sparqlStar);
       return Parser.prototype.parse.apply(parser, arguments);
     };

--- a/test/SparqlParser-test.js
+++ b/test/SparqlParser-test.js
@@ -1,7 +1,7 @@
 var SparqlParser = require('../sparql').Parser;
 
 var fs = require('fs');
-var DataFactory = require('n3').DataFactory;
+var { DataFactory } = require('rdf-data-factory');
 
 var expect = require("expect");
 var toEqualParsedQuery = require("../test/matchers/toEqualParsedQuery");
@@ -9,6 +9,7 @@ expect.extend({
   toEqualParsedQuery,
 });
 
+var dataFactory = new DataFactory();
 var queriesPath = __dirname + '/../queries/';
 var parsedQueriesPath = __dirname + '/../test/parsedQueries/';
 
@@ -96,25 +97,25 @@ describe('A SPARQL parser', function () {
 
     it('should use those prefixes', function () {
       var query = 'SELECT * { a:a b:b "" }';
-      var result_json = {subject: DataFactory.namedNode('ex:abc#a'),
-      predicate: DataFactory.namedNode('ex:def#b'),
-      object: DataFactory.literal("")};
+      var result_json = {subject: dataFactory.namedNode('ex:abc#a'),
+      predicate: dataFactory.namedNode('ex:def#b'),
+      object: dataFactory.literal("")};
 
       expect(parser.parse(query).where[0].triples[0]).toEqual(result_json);
     });
 
     it('should allow temporarily overriding prefixes', function () {
       var query = 'PREFIX a: <ex:xyz#> SELECT * { a:a b:b "" }';
-      var result = {subject: DataFactory.namedNode("ex:xyz#a"),
-        predicate:DataFactory.namedNode("ex:def#b"),
-        object: DataFactory.literal(""),
+      var result = {subject: dataFactory.namedNode("ex:xyz#a"),
+        predicate:dataFactory.namedNode("ex:def#b"),
+        object: dataFactory.literal(""),
       };
       expect(parser.parse(query).where[0].triples[0]).toEqualParsedQuery(result);
 
       var query2 = 'SELECT * { a:a b:b "" }';
-      var result2 = {subject: DataFactory.namedNode("ex:abc#a"),
-        predicate:DataFactory.namedNode("ex:def#b"),
-        object: DataFactory.literal(""),
+      var result2 = {subject: dataFactory.namedNode("ex:abc#a"),
+        predicate:dataFactory.namedNode("ex:def#b"),
+        object: dataFactory.literal(""),
       };
       expect(parser.parse(query2).where[0].triples[0]).toEqualParsedQuery(result2);
     });
@@ -125,9 +126,9 @@ describe('A SPARQL parser', function () {
 
     it('should not take over changes to the original prefixes', function () {
       var query = 'SELECT * { a:a b:b "" }';
-      var result = {subject: DataFactory.namedNode("ex:abc#a"),
-        predicate: DataFactory.namedNode("ex:def#b"),
-        object: DataFactory.literal("")
+      var result = {subject: dataFactory.namedNode("ex:abc#a"),
+        predicate: dataFactory.namedNode("ex:def#b"),
+        object: dataFactory.literal("")
       };
       prefixes.a = 'ex:xyz#';
 
@@ -141,9 +142,9 @@ describe('A SPARQL parser', function () {
     it('should use the base IRI', function () {
       var query = 'SELECT * { <> <#b> "" }';
       var result = '{"subject":{"termType":"NamedNode","value":"http://ex.org/"},"predicate":{"termType":"NamedNode","value":""},"object":{"termType":"Literal","value":"","language":"","datatype":{"termType":"NamedNode","value":"http://www.w3.org/2001/XMLSchema#string"}}}';
-      var result = {subject: DataFactory.namedNode("http://ex.org/"),
-        predicate: DataFactory.namedNode("http://ex.org/#b"),
-        object: DataFactory.literal("")
+      var result = {subject: dataFactory.namedNode("http://ex.org/"),
+        predicate: dataFactory.namedNode("http://ex.org/#b"),
+        object: dataFactory.literal("")
       };
 
       expect(parser.parse(query).where[0].triples[0]).toEqualParsedQuery(result);
@@ -172,9 +173,9 @@ describe('A SPARQL parser', function () {
               type: "bgp",
               triples: [
                 {
-                  subject: DataFactory.variable("s"),
-                  predicate: DataFactory.variable("p"),
-                  object: DataFactory.variable("o")
+                  subject: dataFactory.variable("s"),
+                  predicate: dataFactory.variable("p"),
+                  object: dataFactory.variable("o")
                 }
               ]
             }
@@ -184,9 +185,9 @@ describe('A SPARQL parser', function () {
           type: "bgp",
           triples: [
             {
-              subject: DataFactory.variable("a"),
-              predicate: DataFactory.variable("b"),
-              object: DataFactory.variable("c")
+              subject: dataFactory.variable("a"),
+              predicate: dataFactory.variable("b"),
+              object: dataFactory.variable("c")
             }
           ]
         }

--- a/test/matchers/toEqualParsedQuery.js
+++ b/test/matchers/toEqualParsedQuery.js
@@ -1,5 +1,6 @@
 const diff = require('jest-diff');
-const { Term } = require('n3');
+const {Wildcard} = require('../../lib/Wildcard');
+const {BlankNode, Variable, NamedNode, DefaultGraph, Quad} = require('rdf-data-factory');
 
 function toEqualParsedQuery(received, expected) {
     const options = {
@@ -43,9 +44,9 @@ let objectsEqual = function (received, expected){
         return received === expected;
     }
 
-    if (received instanceof Term){
+    if (isTerm(received)) {
         return received.equals(expected);
-    } else if (expected instanceof Term){
+    } else if (isTerm(expected)) {
         return expected.equals(received);
     } else {
         if (Array.isArray(received)){
@@ -65,6 +66,15 @@ let objectsEqual = function (received, expected){
         return true;
     }
 };
+
+function isTerm(value) {
+    return value instanceof DefaultGraph
+        || value instanceof NamedNode
+        || value instanceof BlankNode
+        || value instanceof Variable
+        || value instanceof Wildcard
+        || value instanceof Quad;
+}
 
 function isPrimitive(value){
     return typeof value === "string" || typeof value === "number" || typeof value === "boolean";


### PR DESCRIPTION
As per #121 , this PR replaces `n3.DataFactory` to a stand-alone implementation of the RDF/JS `DataFactory` interface to reduce the overall bundle size of Comunica for those configurations that do not make use of `n3`'s parsers and/or serializers.

A few notes:

- The `rdf-data-factory` package does not export a shared `Term` abstract class the same way `n3` does. This is what motivated the change to `Wildcard` but most importantly to `toEqualParsedQuery.js`, where I've had to add the `isTerm()` function.
- The latter could perhaps be improved, performance wise, by doing something like `return value && (value instanceof Quad || value.termType)` but that felt a little hackish and obscure, so I opted for multiple `instanceof`s.