### PR TITLE
Added flag to disable checking of ungrouped variables

### DIFF
--- a/lib/sparql.jison
+++ b/lib/sparql.jison
@@ -568,6 +568,7 @@ SelectQuery
     | SelectClauseVars     DatasetClause* WhereClause SolutionModifier
     {
       // Check for projection of ungrouped variable
+      if (Parser.skipUngroupedVariableCheck) return;
       const counts = flatten($1.variables.map(vars => getAggregatesOfExpression(vars.expression)))
         .some(agg => agg.aggregation === "count" && !(agg.expression instanceof Wildcard));
       if (counts || $4.group) {

--- a/sparql.js
+++ b/sparql.js
@@ -13,7 +13,7 @@ module.exports = {
    *   sparqlStar?: boolean,
    * }
    */
-  Parser: function ({ prefixes, baseIRI, factory, sparqlStar } = {}) {
+  Parser: function ({ prefixes, baseIRI, factory, sparqlStar, skipUngroupedVariableCheck } = {}) {
     // Create a copy of the prefixes
     var prefixesCopy = {};
     for (var prefix in prefixes || {})
@@ -27,6 +27,7 @@ module.exports = {
       Parser.prefixes = Object.create(prefixesCopy);
       Parser.factory = factory || new DataFactory();
       Parser.sparqlStar = Boolean(sparqlStar);
+      Parser.skipUngroupedVariableCheck = Boolean(skipUngroupedVariableCheck)
       return Parser.prototype.parse.apply(parser, arguments);
     };
     parser._resetBlanks = Parser._resetBlanks;

--- a/test/SparqlParser-test.js
+++ b/test/SparqlParser-test.js
@@ -50,6 +50,21 @@ describe('A SPARQL parser', function () {
     expect(error.message).toContain("Projection of ungrouped variable (?o)");
   });
 
+  describe("with variable group checks disabled", function() {
+    var parserWithoutValidation = new SparqlParser({skipUngroupedVariableCheck:true});
+
+    // Ensure the same blank node identifiers are used in every test
+    beforeEach(function () { parser._resetBlanks(); });
+
+    it('should not throw an error on a projection of ungrouped variable', function () {
+      var query = 'PREFIX : <http://www.example.org/> SELECT ?o WHERE { ?s ?p ?o } GROUP BY ?s', error = null;
+      var error = null;
+      try { parserWithoutValidation.parse(query); }
+      catch (e) { error = e; }
+      expect(error).toBeNull();
+    });
+  })
+
   it('should throw an error on a use of an ungrouped variable for a projection of an operation', function () {
     var query = 'PREFIX : <http://www.example.org/> SELECT ?o (?o + ?p AS ?c) WHERE { ?s ?p ?o } GROUP BY (?o)';
     var error = null;
@@ -59,6 +74,15 @@ describe('A SPARQL parser', function () {
     expect(error).not.toBeUndefined();
     expect(error).toBeInstanceOf(Error);
     expect(error.message).toContain("Use of ungrouped variable in projection of operation (?p)");
+  });
+
+  //Setting test to skipped. Enable this test once https://github.com/RubenVerborgh/SPARQL.js/issues/120 is resolved.
+  it.skip('should not throw an ungrouped variable error when the query is valid', function () {
+    var query = 'select ?s (?x as ?y) {?s ?p ?x.} group by ?s';
+    var error = null;
+    try { parser.parse(query); }
+    catch (e) { error = e; }
+    expect(error).toBeNull();
   });
 
   it('should throw an error on an invalid bindscope', function () {


### PR DESCRIPTION
This PR should provide a workaround for the false errors described in #120

- I added a `skipUngroupedVariableCheck` option to skip checking for ungrouped variables. If you have a different name in mind, let me know (`strict` mode was already taken ;) )
- While I was at it, also added a test (set to `skip()`) that reproduces the issue from #120 in the test suite