### PR TITLE
Always update base to Parser.base

### DIFF
--- a/lib/sparql.jison
+++ b/lib/sparql.jison
@@ -61,7 +61,7 @@
       return iri;
     if (!Parser.base)
       throw new Error('Cannot resolve relative IRI ' + iri + ' because no base IRI was set.');
-    if (!base) {
+    if (base !== Parser.base) {
       base = Parser.base;
       basePath = base.replace(/[^\/:]*$/, '');
       baseRoot = base.match(/^(?:[a-z]+:\/*)?[^\/]*/)[0];
@@ -536,7 +536,7 @@ QueryOrUpdate
       $2 = $2 || {};
       if (Parser.base)
         $2.base = Parser.base;
-      Parser.base = base = basePath = baseRoot = '';
+      Parser.base = '';
       $2.prefixes = Parser.prefixes;
       Parser.prefixes = null;
       return $2;
@@ -551,7 +551,6 @@ BaseDecl
     : 'BASE' IRIREF
     {
       Parser.base = resolveIRI($2)
-      base = basePath = baseRoot = '';
     }
     ;
 PrefixDecl

--- a/test/SparqlParser-test.js
+++ b/test/SparqlParser-test.js
@@ -141,13 +141,27 @@ describe('A SPARQL parser', function () {
 
     it('should use the base IRI', function () {
       var query = 'SELECT * { <> <#b> "" }';
-      var result = '{"subject":{"termType":"NamedNode","value":"http://ex.org/"},"predicate":{"termType":"NamedNode","value":""},"object":{"termType":"Literal","value":"","language":"","datatype":{"termType":"NamedNode","value":"http://www.w3.org/2001/XMLSchema#string"}}}';
       var result = {subject: dataFactory.namedNode("http://ex.org/"),
         predicate: dataFactory.namedNode("http://ex.org/#b"),
         object: dataFactory.literal("")
       };
 
       expect(parser.parse(query).where[0].triples[0]).toEqualParsedQuery(result);
+    });
+
+    it('should work after a previous query failed', function () {
+      var badQuery = 'SELECT * { <> <#b> "" } invalid!';
+      expect(() => parser.parse(badQuery)).toThrow(Error);
+
+      var goodQuery = 'SELECT * { <> <#b> "" }';
+
+      parser = new SparqlParser({ baseIRI: 'http://ex2.org/' });
+      var result = {subject: dataFactory.namedNode("http://ex2.org/"),
+        predicate: dataFactory.namedNode("http://ex2.org/#b"),
+        object: dataFactory.literal("")
+      };
+      var data = parser.parse(goodQuery);
+      expect(data.where[0].triples[0]).toEqualParsedQuery(result);
     });
   });
 
@@ -164,7 +178,6 @@ describe('A SPARQL parser', function () {
   describe('with group collapsing disabled', function () {
     it('should keep explicit pattern group', function () {
       var query = 'SELECT * WHERE { { ?s ?p ?o } ?a ?b ?c }';
-      var result = ',"object":{"termType":"Variable","value":"c"}}]}]';
       var result = [
         {
           type: "group",


### PR DESCRIPTION
Closes #130.

The internal `base` variable now always gets updated if it doesn't match `Parser.base`, which is what was already happening in case there was no crash.

Added relevant unit test that failed before this change.

(Also removed 2 useless test line).