### PR TITLE
Spec-compliance for update queries

### DIFF
--- a/lib/sparql.jison
+++ b/lib/sparql.jison
@@ -426,12 +426,14 @@ PLX                   {PERCENT}|{PN_LOCAL_ESC}
 PERCENT               "%"{HEX}{HEX}
 HEX                   [0-9A-Fa-f]
 PN_LOCAL_ESC          "\\"("_"|"~"|"."|"-"|"!"|"$"|"&"|"'"|"("|")"|"*"|"+"|","|";"|"="|"/"|"?"|"#"|"@"|"%")
+COMMENT               "#"[^\n\r]*
+SPACES_COMMENTS       (\s+|{COMMENT})+
 
 %options flex case-insensitive
 
 %%
 
-\s+|"#"[^\n\r]*          /* ignore */
+\s+|{COMMENT}            /* ignore */
 "BASE"                   return 'BASE'
 "PREFIX"                 return 'PREFIX'
 "SELECT"                 return 'SELECT'
@@ -469,9 +471,9 @@ PN_LOCAL_ESC          "\\"("_"|"~"|"."|"-"|"!"|"$"|"&"|"'"|"("|")"|"*"|"+"|","|"
 "TO"                     return 'TO'
 "MOVE"                   return 'MOVE'
 "COPY"                   return 'COPY'
-"INSERT"\s+"DATA"        return 'INSERTDATA'
-"DELETE"\s+"DATA"        return 'DELETEDATA'
-"DELETE"\s+"WHERE"       return 'DELETEWHERE'
+"INSERT"{SPACES_COMMENTS}"DATA"  return 'INSERTDATA'
+"DELETE"{SPACES_COMMENTS}"DATA"  return 'DELETEDATA'
+"DELETE"{SPACES_COMMENTS}"WHERE" return 'DELETEWHERE'
 "WITH"                   return 'WITH'
 "DELETE"                 return 'DELETE'
 "INSERT"                 return 'INSERT'

--- a/lib/sparql.jison
+++ b/lib/sparql.jison
@@ -178,6 +178,7 @@
   var escapeSequence = /\\u([a-fA-F0-9]{4})|\\U([a-fA-F0-9]{8})|\\(.)/g,
       escapeReplacements = { '\\': '\\', "'": "'", '"': '"',
                              't': '\t', 'b': '\b', 'n': '\n', 'r': '\r', 'f': '\f' },
+      partialSurrogatesWithoutEndpoint = /[\uD800-\uDBFF]([^\uDC00-\uDFFF]|$)/,
       fromCharCode = String.fromCharCode;
 
   // Translates escape codes in the string into their textual equivalent
@@ -205,6 +206,12 @@
       });
     }
     catch (error) { return ''; }
+
+    // Test for invalid unicode surrogate pairs
+    if (partialSurrogatesWithoutEndpoint.exec(string)) {
+      throw new Error('Invalid unicode codepoint of surrogate pair without corresponding codepoint in ' + string);
+    }
+
     return string;
   }
 

--- a/lib/sparql.jison
+++ b/lib/sparql.jison
@@ -434,7 +434,7 @@ PERCENT               "%"{HEX}{HEX}
 HEX                   [0-9A-Fa-f]
 PN_LOCAL_ESC          "\\"("_"|"~"|"."|"-"|"!"|"$"|"&"|"'"|"("|")"|"*"|"+"|","|";"|"="|"/"|"?"|"#"|"@"|"%")
 COMMENT               "#"[^\n\r]*
-SPACES_COMMENTS       (\s+|{COMMENT})+
+SPACES_COMMENTS       (\s+|{COMMENT}\n\r?)+
 
 %options flex case-insensitive
 

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "spec-base-update": "rdf-test-suite spec/parser.js http://w3c.github.io/rdf-tests/sparql11/data-sparql11/manifest-all.ttl -s http://www.w3.org/TR/sparql11-update/ -c .rdf-test-suite-cache/",
     "spec-earl-query": "npm run spec-base-query --silent -- -o earl -p spec/earl-meta.json > spec/earl-query.ttl",
     "spec-earl-update": "npm run spec-base-update --silent -- -o earl -p spec/earl-meta.json > spec/earl-update.ttl",
-    "spec": "npm run spec-base-query -- && npm run spec-base-update --"
+    "spec": "npm run spec-base-query && npm run spec-base-update"
   },
   "engines": {
     "node": ">=8.0"

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "spec-base-update": "rdf-test-suite spec/parser.js http://w3c.github.io/rdf-tests/sparql11/data-sparql11/manifest-all.ttl -s http://www.w3.org/TR/sparql11-update/ -c .rdf-test-suite-cache/",
     "spec-earl-query": "npm run spec-base-query --silent -- -o earl -p spec/earl-meta.json > spec/earl-query.ttl",
     "spec-earl-update": "npm run spec-base-update --silent -- -o earl -p spec/earl-meta.json > spec/earl-update.ttl",
-    "spec": "npm run spec-base-query -- && npm run spec-base-update -- -e"
+    "spec": "npm run spec-base-query -- && npm run spec-base-update --"
   },
   "engines": {
     "node": ">=8.0"

--- a/spec/parser.js
+++ b/spec/parser.js
@@ -9,4 +9,7 @@ module.exports = {
   query: function() {
     return Promise.reject(new ErrorSkipped('Querying is not supported'));
   },
+  update: function() {
+    return Promise.reject(new ErrorSkipped('Updating is not supported'));
+  },
 };

--- a/test/SparqlParser-test.js
+++ b/test/SparqlParser-test.js
@@ -226,6 +226,76 @@ describe('A SPARQL parser', function () {
       )).toThrow(expectedErrorMessage);
     });
   });
+
+  describe('for update queries', () => {
+    it('should throw on blank nodes in DELETE clause', function () {
+      var query = 'DELETE { ?a <ex:knows> [] . } WHERE { ?a <ex:knows> "Alan" . }', error = null;
+      try { parser.parse(query); }
+      catch (e) { error = e; }
+
+      expect(error).not.toBeUndefined();
+      expect(error).toBeInstanceOf(Error);
+      expect(error.message).toContain('Detected illegal blank node in BGP');
+    });
+
+    it('should not throw on blank nodes in INSERT clause', function () {
+      var query = 'INSERT { ?a <ex:knows> [] . } WHERE { ?a <ex:knows> "Alan" . }', error = null;
+      try { parser.parse(query); }
+      catch (e) { error = e; }
+
+      expect(error).toBeNull();
+    });
+
+    it('should throw on blank nodes in compact DELETE clause', function () {
+      var query = 'DELETE WHERE { _:a <ex:p> <ex:o> }', error = null;
+      try { parser.parse(query); }
+      catch (e) { error = e; }
+
+      expect(error).not.toBeUndefined();
+      expect(error).toBeInstanceOf(Error);
+      expect(error.message).toContain('Detected illegal blank node in BGP');
+    });
+
+    it('should throw on variables in DELETE DATA clause', function () {
+      var query = 'DELETE DATA { ?a <ex:p> <ex:o> }', error = null;
+      try { parser.parse(query); }
+      catch (e) { error = e; }
+
+      expect(error).not.toBeUndefined();
+      expect(error).toBeInstanceOf(Error);
+      expect(error.message).toContain('Detected illegal variable in BGP');
+    });
+
+    it('should throw on blank nodes in DELETE DATA clause', function () {
+      var query = 'DELETE DATA { _:a <ex:p> <ex:o> }', error = null;
+      try { parser.parse(query); }
+      catch (e) { error = e; }
+
+      expect(error).not.toBeUndefined();
+      expect(error).toBeInstanceOf(Error);
+      expect(error.message).toContain('Detected illegal blank node in BGP');
+    });
+
+    it('should throw on variables in DELETE DATA clause with GRAPH', function () {
+      var query = 'DELETE DATA { GRAPH ?a { <ex:s> <ex:p> <ex:o> } }', error = null;
+      try { parser.parse(query); }
+      catch (e) { error = e; }
+
+      expect(error).not.toBeUndefined();
+      expect(error).toBeInstanceOf(Error);
+      expect(error.message).toContain('Detected illegal variable in GRAPH');
+    });
+
+    it('should throw on variables in INSERT DATA clause', function () {
+      var query = 'INSERT DATA { ?a <ex:p> <ex:o> }', error = null;
+      try { parser.parse(query); }
+      catch (e) { error = e; }
+
+      expect(error).not.toBeUndefined();
+      expect(error).toBeInstanceOf(Error);
+      expect(error.message).toContain('Detected illegal variable in BGP');
+    });
+  });
 });
 
 function testQueries(directory, settings) {

--- a/test/SparqlParser-test.js
+++ b/test/SparqlParser-test.js
@@ -295,6 +295,44 @@ describe('A SPARQL parser', function () {
       expect(error).toBeInstanceOf(Error);
       expect(error.message).toContain('Detected illegal variable in BGP');
     });
+
+    it('should throw on variables in DELETE DATA clause with GRAPH', function () {
+      var query = 'DELETE DATA { GRAPH ?a { <ex:s> <ex:p> <ex:o> } }', error = null;
+      try { parser.parse(query); }
+      catch (e) { error = e; }
+
+      expect(error).not.toBeUndefined();
+      expect(error).toBeInstanceOf(Error);
+      expect(error.message).toContain('Detected illegal variable in GRAPH');
+    });
+
+    it('should not throw on reused blank nodes in one INSERT DATA clause', function () {
+      var query = 'INSERT DATA { _:a <ex:p> <ex:o> . _:a <ex:p> <ex:o> . }', error = null;
+      try { parser.parse(query); }
+      catch (e) { error = e; }
+
+      expect(error).toBeNull();
+    });
+
+    it('should throw on reused blank nodes across INSERT DATA clauses', function () {
+      var query = 'INSERT DATA { _:a <ex:p> <ex:o> }; INSERT DATA { _:a <ex:p> <ex:o> }', error = null;
+      try { parser.parse(query); }
+      catch (e) { error = e; }
+
+      expect(error).not.toBeUndefined();
+      expect(error).toBeInstanceOf(Error);
+      expect(error.message).toContain('Detected reuse blank node across different INSERT DATA clauses');
+    });
+
+    it('should throw on reused blank nodes across INSERT DATA clauses with GRAPH', function () {
+      var query = 'INSERT DATA { _:a <ex:p> <ex:o> }; INSERT DATA { GRAPH <ex:g> { _:a <ex:p> <ex:o> } }', error = null;
+      try { parser.parse(query); }
+      catch (e) { error = e; }
+
+      expect(error).not.toBeUndefined();
+      expect(error).toBeInstanceOf(Error);
+      expect(error.message).toContain('Detected reuse blank node across different INSERT DATA clauses');
+    });
   });
 });
 

--- a/test/SparqlParser-test.js
+++ b/test/SparqlParser-test.js
@@ -343,6 +343,25 @@ DATA { GRAPH <ex:G> { <ex:s> <ex:p> 'o1', 'o2', 'o3' } }`, error = null;
 
       expect(error).toBeNull();
     });
+
+    it('should not throw on comment after INSERT that could be confused with DATA', function () {
+      var query = `INSERT # DATA
+DATA { GRAPH <ex:G> { <ex:s> <ex:p> 'o1', 'o2', 'o3' } }`, error = null;
+      try { parser.parse(query); }
+      catch (e) { error = e; }
+
+      expect(error).toBeNull();
+    });
+
+    it('should throw on commented DATA after INSERT', function () {
+      var query = `INSERT # DATA { GRAPH <ex:G> { <ex:s> <ex:p> 'o1', 'o2', 'o3' } }`, error = null;
+      try { parser.parse(query); }
+      catch (e) { error = e; }
+
+      expect(error).not.toBeUndefined();
+      expect(error).toBeInstanceOf(Error);
+      expect(error.message).toContain('Parse error');
+    });
   });
 
   it('should throw an error on unicode codepoint escaping in literal with partial surrogate pair', function () {

--- a/test/SparqlParser-test.js
+++ b/test/SparqlParser-test.js
@@ -344,6 +344,26 @@ DATA { GRAPH <ex:G> { <ex:s> <ex:p> 'o1', 'o2', 'o3' } }`, error = null;
       expect(error).toBeNull();
     });
   });
+
+  it('should throw an error on unicode codepoint escaping in literal with partial surrogate pair', function () {
+    var query = "SELECT * WHERE { ?s <ex:p> '\uD800' }";
+    var error = null;
+    try { parser.parse(query); }
+    catch (e) { error = e; }
+
+    expect(error).not.toBeUndefined();
+    expect(error).toBeInstanceOf(Error);
+    expect(error.message).toContain("Invalid unicode codepoint of surrogate pair without corresponding codepoint");
+  });
+
+  it('should not throw an error on unicode codepoint escaping in literal with complete surrogate pair', function () {
+    var query = "SELECT * WHERE { ?s <ex:p> '\uD800\uDFFF' }";
+    var error = null;
+    try { parser.parse(query); }
+    catch (e) { error = e; }
+
+    expect(error).toBeNull();
+  });
 });
 
 function testQueries(directory, settings) {

--- a/test/SparqlParser-test.js
+++ b/test/SparqlParser-test.js
@@ -333,6 +333,16 @@ describe('A SPARQL parser', function () {
       expect(error).toBeInstanceOf(Error);
       expect(error.message).toContain('Detected reuse blank node across different INSERT DATA clauses');
     });
+
+    it('should not throw on comment between INSERT and DATA', function () {
+      var query = `INSERT
+# Comment
+DATA { GRAPH <ex:G> { <ex:s> <ex:p> 'o1', 'o2', 'o3' } }`, error = null;
+      try { parser.parse(query); }
+      catch (e) { error = e; }
+
+      expect(error).toBeNull();
+    });
   });
 });
 


### PR DESCRIPTION
This PR makes sure that all spec tests are passed for parsing update queries.

I've also included a commit regarding a unicode validity check for a recent spec test, so that all the latest (query) spec tests also pass.

So after this PR is merged, this lib is 100% spec-compliant 🎉 

This is the first time I work with jison, so please let me know if certain things could be improved.

Closes #129