### PR TITLE
Issue 99 - Fix blank node triple pattern with property paths

### DIFF
--- a/lib/sparql.jison
+++ b/lib/sparql.jison
@@ -931,6 +931,9 @@ Verb
 ObjectList
     : (GraphNode ',')* GraphNode -> appendTo($1, $2)
     ;
+ObjectListPath
+    : (GraphNodePath ',')* GraphNodePath -> appendTo($1, $2)
+    ;
 TriplesSameSubjectPath
     : (VarOrTerm | VarTriple) PropertyListPathNotEmpty -> $2.map(function (t) { return extend(triple($1), t); })
     | TriplesNodePath PropertyListPathNotEmpty? -> !$2 ? $1.triples : appendAllTo($2.map(function (t) { return extend(triple($1.entity), t); }), $1.triples) /* the subject is a blank node, possibly with more triples */
@@ -940,7 +943,7 @@ PropertyListPathNotEmpty
     ;
 PropertyListPathNotEmptyTail
     : ';' -> []
-    | ';' ( Path | VAR ) ObjectList -> objectListToTriples(toVar($2), $3)
+    | ';' ( Path | VAR ) ObjectListPath -> objectListToTriples(toVar($2), $3)
     ;
 Path
     : ( PathSequence '|' )* PathSequence -> $1.length ? path('|',appendTo($1, $2)) : $2

--- a/queries/sparql/sparql-18-a.sparql
+++ b/queries/sparql/sparql-18-a.sparql
@@ -1,0 +1,10 @@
+PREFIX dbpedia-owl:<http://dbpedia.org/owl/#>
+PREFIX rdfs:<http://www.w3.org/2000/01/rdf-schema#>
+SELECT ?movie
+WHERE {
+  ?movie a dbpedia-owl:Film ;
+    dbpedia-owl:starring [
+      rdfs:label "Brad Pitt"@en ;
+      ^dbpedia-owl:starring ?otherMovie
+    ] .
+}

--- a/queries/sparql/sparql-18-b.sparql
+++ b/queries/sparql/sparql-18-b.sparql
@@ -1,0 +1,14 @@
+prefix example: <http://example/id/>
+PREFIX rdfs:<http://www.w3.org/2000/01/rdf-schema#>
+PREFIX rdf:<http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+select ?s ?p ?o {
+    # ok
+    ?s  rdf:type [ example:prop* ?o ] .
+    # ok
+    ?s  rdf:type [ example:prop* ?o ] ;
+        example:p2 ?_ .
+    # error 
+    ?s  example:p1 ?_ ; 
+        rdf:type [ example:prop* ?o ] ;
+        example:p2 ?o .
+}

--- a/queries/sparql/sparql-18-b.sparql
+++ b/queries/sparql/sparql-18-b.sparql
@@ -2,12 +2,9 @@ prefix example: <http://example/id/>
 PREFIX rdfs:<http://www.w3.org/2000/01/rdf-schema#>
 PREFIX rdf:<http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 select ?s ?p ?o {
-    # ok
     ?s  rdf:type [ example:prop* ?o ] .
-    # ok
     ?s  rdf:type [ example:prop* ?o ] ;
         example:p2 ?_ .
-    # error 
     ?s  example:p1 ?_ ; 
         rdf:type [ example:prop* ?o ] ;
         example:p2 ?o .

--- a/queries/sparql/sparql-18-c.sparql
+++ b/queries/sparql/sparql-18-c.sparql
@@ -1,0 +1,7 @@
+prefix : <https://ex.com/>
+select ?a {
+:a ?a :a ;
+  :a [
+    :a/:a :a
+  ] .
+}

--- a/test/parsedQueries/sparql/sparql-18-a.json
+++ b/test/parsedQueries/sparql/sparql-18-a.json
@@ -1,0 +1,88 @@
+{
+  "queryType": "SELECT",
+  "variables": [
+    {
+      "termType": "Variable",
+      "value": "movie"
+    }
+  ],
+  "where": [
+    {
+      "type": "bgp",
+      "triples": [
+        {
+          "subject": {
+            "termType": "Variable",
+            "value": "movie"
+          },
+          "predicate": {
+            "termType": "NamedNode",
+            "value": "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+          },
+          "object": {
+            "termType": "NamedNode",
+            "value": "http://dbpedia.org/owl/#Film"
+          }
+        },
+        {
+          "subject": {
+            "termType": "Variable",
+            "value": "movie"
+          },
+          "predicate": {
+            "termType": "NamedNode",
+            "value": "http://dbpedia.org/owl/#starring"
+          },
+          "object": {
+            "termType": "BlankNode",
+            "value": "g_0"
+          }
+        },
+        {
+          "subject": {
+            "termType": "BlankNode",
+            "value": "g_0"
+          },
+          "predicate": {
+            "termType": "NamedNode",
+            "value": "http://www.w3.org/2000/01/rdf-schema#label"
+          },
+          "object": {
+            "termType": "Literal",
+            "value": "Brad Pitt",
+            "language": "en",
+            "datatype": {
+              "termType": "NamedNode",
+              "value": "http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"
+            }
+          }
+        },
+        {
+          "subject": {
+            "termType": "BlankNode",
+            "value": "g_0"
+          },
+          "predicate": {
+            "type": "path",
+            "pathType": "^",
+            "items": [
+              {
+                "termType": "NamedNode",
+                "value": "http://dbpedia.org/owl/#starring"
+              }
+            ]
+          },
+          "object": {
+            "termType": "Variable",
+            "value": "otherMovie"
+          }
+        }
+      ]
+    }
+  ],
+  "type": "query",
+  "prefixes": {
+    "dbpedia-owl": "http://dbpedia.org/owl/#",
+    "rdfs": "http://www.w3.org/2000/01/rdf-schema#"
+  }
+}

--- a/test/parsedQueries/sparql/sparql-18-b.json
+++ b/test/parsedQueries/sparql/sparql-18-b.json
@@ -1,0 +1,174 @@
+{
+  "queryType": "SELECT",
+  "variables": [
+    {
+      "termType": "Variable",
+      "value": "s"
+    },
+    {
+      "termType": "Variable",
+      "value": "p"
+    },
+    {
+      "termType": "Variable",
+      "value": "o"
+    }
+  ],
+  "where": [
+    {
+      "type": "bgp",
+      "triples": [
+        {
+          "subject": {
+            "termType": "Variable",
+            "value": "s"
+          },
+          "predicate": {
+            "termType": "NamedNode",
+            "value": "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+          },
+          "object": {
+            "termType": "BlankNode",
+            "value": "g_0"
+          }
+        },
+        {
+          "subject": {
+            "termType": "BlankNode",
+            "value": "g_0"
+          },
+          "predicate": {
+            "type": "path",
+            "pathType": "*",
+            "items": [
+              {
+                "termType": "NamedNode",
+                "value": "http://example/id/prop"
+              }
+            ]
+          },
+          "object": {
+            "termType": "Variable",
+            "value": "o"
+          }
+        },
+        {
+          "subject": {
+            "termType": "Variable",
+            "value": "s"
+          },
+          "predicate": {
+            "termType": "NamedNode",
+            "value": "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+          },
+          "object": {
+            "termType": "BlankNode",
+            "value": "g_1"
+          }
+        },
+        {
+          "subject": {
+            "termType": "Variable",
+            "value": "s"
+          },
+          "predicate": {
+            "termType": "NamedNode",
+            "value": "http://example/id/p2"
+          },
+          "object": {
+            "termType": "Variable",
+            "value": "_"
+          }
+        },
+        {
+          "subject": {
+            "termType": "BlankNode",
+            "value": "g_1"
+          },
+          "predicate": {
+            "type": "path",
+            "pathType": "*",
+            "items": [
+              {
+                "termType": "NamedNode",
+                "value": "http://example/id/prop"
+              }
+            ]
+          },
+          "object": {
+            "termType": "Variable",
+            "value": "o"
+          }
+        },
+        {
+          "subject": {
+            "termType": "Variable",
+            "value": "s"
+          },
+          "predicate": {
+            "termType": "NamedNode",
+            "value": "http://example/id/p1"
+          },
+          "object": {
+            "termType": "Variable",
+            "value": "_"
+          }
+        },
+        {
+          "subject": {
+            "termType": "Variable",
+            "value": "s"
+          },
+          "predicate": {
+            "termType": "NamedNode",
+            "value": "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+          },
+          "object": {
+            "termType": "BlankNode",
+            "value": "g_2"
+          }
+        },
+        {
+          "subject": {
+            "termType": "BlankNode",
+            "value": "g_2"
+          },
+          "predicate": {
+            "type": "path",
+            "pathType": "*",
+            "items": [
+              {
+                "termType": "NamedNode",
+                "value": "http://example/id/prop"
+              }
+            ]
+          },
+          "object": {
+            "termType": "Variable",
+            "value": "o"
+          }
+        },
+        {
+          "subject": {
+            "termType": "Variable",
+            "value": "s"
+          },
+          "predicate": {
+            "termType": "NamedNode",
+            "value": "http://example/id/p2"
+          },
+          "object": {
+            "termType": "Variable",
+            "value": "o"
+          }
+        }
+      ]
+    }
+  ],
+  "type": "query",
+  "prefixes": {
+    "example": "http://example/id/",
+    "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+    "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+  }
+}

--- a/test/parsedQueries/sparql/sparql-18-c.json
+++ b/test/parsedQueries/sparql/sparql-18-c.json
@@ -1,0 +1,72 @@
+{
+  "queryType": "SELECT",
+  "variables": [
+    {
+      "termType": "Variable",
+      "value": "a"
+    }
+  ],
+  "where": [
+    {
+      "type": "bgp",
+      "triples": [
+        {
+          "subject": {
+            "termType": "NamedNode",
+            "value": "https://ex.com/a"
+          },
+          "predicate": {
+            "termType": "Variable",
+            "value": "a"
+          },
+          "object": {
+            "termType": "NamedNode",
+            "value": "https://ex.com/a"
+          }
+        },
+        {
+          "subject": {
+            "termType": "NamedNode",
+            "value": "https://ex.com/a"
+          },
+          "predicate": {
+            "termType": "NamedNode",
+            "value": "https://ex.com/a"
+          },
+          "object": {
+            "termType": "BlankNode",
+            "value": "g_0"
+          }
+        },
+        {
+          "subject": {
+            "termType": "BlankNode",
+            "value": "g_0"
+          },
+          "predicate": {
+            "type": "path",
+            "pathType": "/",
+            "items": [
+              {
+                "termType": "NamedNode",
+                "value": "https://ex.com/a"
+              },
+              {
+                "termType": "NamedNode",
+                "value": "https://ex.com/a"
+              }
+            ]
+          },
+          "object": {
+            "termType": "NamedNode",
+            "value": "https://ex.com/a"
+          }
+        }
+      ]
+    }
+  ],
+  "type": "query",
+  "prefixes": {
+    "": "https://ex.com/"
+  }
+}


### PR DESCRIPTION
When blank node triple patterns of the form `[ :p "v" ] .` contained
property paths, the parsed throwed an exception because it didn't expect
it. This happened because the parser entered the ObjectList rule that
doesn't handle the property path case. So instead of having PropertyListPathNotEmptyTail
calling the ObjectList rule, I added a ObjectListPath rule that is
called instead and that calls GraphNodePath, following the same pattern
of -Path suffixed rules in this parser to make sure that property paths
arent allowed in other queries such as construct queries.

To the unit tests I've added the queries posted in the issue

https://github.com/RubenVerborgh/SPARQL.js/issues/99

Reference: https://www.w3.org/TR/2013/REC-sparql11-query-20130321/#QSynBlankNodes