### PR TITLE
Fix sparql generator for SPARQL 1.1 update ADD, MOVE, COPY operations

### DIFF
--- a/lib/SparqlGenerator.js
+++ b/lib/SparqlGenerator.js
@@ -382,8 +382,8 @@ Generator.prototype.toUpdate = function (update) {
   case 'add':
   case 'copy':
   case 'move':
-    return update.type.toUpperCase() + (update.source.default ? ' DEFAULT ' : ' ') +
-           'TO ' + this.toEntity(update.destination.name);
+    return update.type.toUpperCase()+ ' ' +  (update.silent ? 'SILENT ' : '') + (update.source.default ? 'DEFAULT' : this.toEntity(update.source.name)) +
+           ' TO ' + this.toEntity(update.destination.name);
   case 'create':
   case 'clear':
   case 'drop':

--- a/test/SparqlGenerator-test.js
+++ b/test/SparqlGenerator-test.js
@@ -93,6 +93,18 @@ describe('A SPARQL generator', function () {
       'GROUP BY ?k';
     expect(generatedQuery).toEqual(expectedQuery);
   });
+
+  // TODO enable once fixed
+  // test currently fails, i.e. sparql.js drops <http://example.com/my-graph> 
+  it.skip('should preserve source graph in sparql 1.1 update graph management operations', function () {
+    var parser = new SparqlParser();
+    var parsedQuery = parser.parse('ADD <http://example.com/my-graph> TO <http://example.com/your-graph>');
+    var generator = new SparqlGenerator();
+    var generatedQuery = generator.stringify(parsedQuery);
+    var expectedQuery =
+      'ADD <http://example.com/my-graph> TO <http://example.com/your-graph>';
+    expect(generatedQuery).toEqual(expectedQuery);
+  });
 });
 
 function testQueries(directory, settings) {

--- a/test/SparqlGenerator-test.js
+++ b/test/SparqlGenerator-test.js
@@ -94,15 +94,33 @@ describe('A SPARQL generator', function () {
     expect(generatedQuery).toEqual(expectedQuery);
   });
 
-  // TODO enable once fixed
-  // test currently fails, i.e. sparql.js drops <http://example.com/my-graph> 
-  it.skip('should preserve source graph in sparql 1.1 update graph management operations', function () {
+  it('should preserve source graph in sparql 1.1 update ADD operation', function () {
     var parser = new SparqlParser();
     var parsedQuery = parser.parse('ADD <http://example.com/my-graph> TO <http://example.com/your-graph>');
     var generator = new SparqlGenerator();
     var generatedQuery = generator.stringify(parsedQuery);
     var expectedQuery =
       'ADD <http://example.com/my-graph> TO <http://example.com/your-graph>';
+    expect(generatedQuery).toEqual(expectedQuery);
+  });
+
+  it('should preserve source, default graph in sparql 1.1 update MOVE operation', function () {
+    var parser = new SparqlParser();
+    var parsedQuery = parser.parse('MOVE DEFAULT TO <http://example.org/named>');
+    var generator = new SparqlGenerator();
+    var generatedQuery = generator.stringify(parsedQuery);
+    var expectedQuery =
+      'MOVE DEFAULT TO <http://example.org/named>';
+    expect(generatedQuery).toEqual(expectedQuery);
+  });
+
+  it('should preserve source, default graph in sparql 1.1 update MOVE operation', function () {
+    var parser = new SparqlParser();
+    var parsedQuery = parser.parse('COPY SILENT DEFAULT TO <http://example.org/named>');
+    var generator = new SparqlGenerator();
+    var generatedQuery = generator.stringify(parsedQuery);
+    var expectedQuery =
+      'COPY SILENT DEFAULT TO <http://example.org/named>';
     expect(generatedQuery).toEqual(expectedQuery);
   });
 });


### PR DESCRIPTION
Fixing #150.
What is a bit strange IMHO, is that in the standard the GRAPH keyword seems to be optional for ADD, MOVE, COPY (c.f.  https://www.w3.org/TR/sparql11-update/#COPY and https://www.w3.org/TR/sparql11-query/#rGraphOrDefault , ) but not for others e.g. https://www.w3.org/TR/sparql11-update/#DROP ("The GRAPH keyword is used to remove a graph denoted by IRIref, the DEFAULT keyword is used to remove the default graph from the Graph Store").

 So I haven't checked yet whether it is possible to preserve the GRAPH, for example, `ADD GRAPH <http://example.com/my-graph> TO GRAPH <http://example.com/your-graph>` instead of `ADD <http://example.com/my-graph> TO <http://example.com/your-graph>` . In the current fix it would simply drop the GRAPH keyword in the roundtrip. I guess that may relate to https://github.com/RubenVerborgh/SPARQL.js/issues/100 ?