### PR TITLE
Serialising a double inverse property path results in a syntactically invalid query

### DIFF
--- a/test/generation/PropertyPath-test.js
+++ b/test/generation/PropertyPath-test.js
@@ -1,0 +1,31 @@
+const SparqlParser = require('../../sparql').Parser;
+const SparqlGenerator = require('../../sparql').Generator;
+const expect = require('expect');
+
+describe('Property Path Support Test', function () {
+
+  it('should unparse double inverse property path', function () {
+    const query = `ASK WHERE { ?s ^(^<a:a>) ?o. }`;
+
+    const sparqlParser = new SparqlParser();
+    let selectQueryAST;
+    try {
+      selectQueryAST = sparqlParser.parse(query);
+    } catch (e) {
+      throw Error(`Could not parse "${query}" :\n${e}`);
+    }
+
+    const generator = new SparqlGenerator({});
+    let outputQueryString;
+    try {
+      outputQueryString = generator.stringify(selectQueryAST);
+    } catch (e) {
+      throw Error(`Could not generate "${JSON.parse(selectQueryAST, null, 2)}" :\n${e}`);
+    }
+
+    const trimedInputQuery = query.replace(/  /g, " ");
+    const trimedOutputQuery = outputQueryString.replace(/  /g, " ");
+
+    expect(trimedOutputQuery).toEqual(trimedInputQuery);
+  });
+});


### PR DESCRIPTION
When serialising the following query, the surrounding `(` `)` are forgotten, causing a syntactically invalid query to be generated:

```rq
ASK WHERE { ?s ^(^<a:a>) ?o. }
```

becomes:

```
ASK WHERE { ?s ^^<a:a> ?o. }
```

which is syntactically invalid.