### PR TITLE
Fix missing graph field in quoted triples

### DIFF
--- a/lib/sparql.jison
+++ b/lib/sparql.jison
@@ -161,12 +161,7 @@
       throw new Error('Nested triples cannot contain paths');
     }
 
-    return {
-      termType: "Quad",
-      subject,
-      predicate,
-      object
-    }
+    return Parser.factory.quad(subject, predicate, object);
   }
 
   // Creates a triple with the given subject, predicate, and object
@@ -999,7 +994,7 @@ GraphRefAll
 // [48]
 QuadPattern
     : '{' Quads '}' -> $2
-    ; 
+    ;
 
 // [50]
 Quads

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "3.7.0",
       "license": "MIT",
       "dependencies": {
-        "rdf-data-factory": "^1.1.1"
+        "rdf-data-factory": "^1.1.2"
       },
       "bin": {
         "sparqljs": "bin/sparql-to-json"
@@ -2627,9 +2627,9 @@
       }
     },
     "node_modules/rdf-data-factory": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/rdf-data-factory/-/rdf-data-factory-1.1.1.tgz",
-      "integrity": "sha512-0HoLx7lbBlNd2YTmNKin0txgiYmAV56eVU823at8cG2+iD0Ia5kcRNDpzZy6I/HCtFTymHvTfdhHTzm3ak3Jpw==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/rdf-data-factory/-/rdf-data-factory-1.1.2.tgz",
+      "integrity": "sha512-TfQD63Lokabd09ES1jAtKK8AA6rkr9rwyUBGo6olOt1CE0Um36CUQIqytyf0am2ouBPR0l7SaHxCiMcPGHkt1A==",
       "dependencies": {
         "@rdfjs/types": "*"
       }
@@ -5699,9 +5699,9 @@
       }
     },
     "rdf-data-factory": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/rdf-data-factory/-/rdf-data-factory-1.1.1.tgz",
-      "integrity": "sha512-0HoLx7lbBlNd2YTmNKin0txgiYmAV56eVU823at8cG2+iD0Ia5kcRNDpzZy6I/HCtFTymHvTfdhHTzm3ak3Jpw==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/rdf-data-factory/-/rdf-data-factory-1.1.2.tgz",
+      "integrity": "sha512-TfQD63Lokabd09ES1jAtKK8AA6rkr9rwyUBGo6olOt1CE0Um36CUQIqytyf0am2ouBPR0l7SaHxCiMcPGHkt1A==",
       "requires": {
         "@rdfjs/types": "*"
       }

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
   },
   "dependencies": {
-    "rdf-data-factory": "^1.1.1"
+    "rdf-data-factory": "^1.1.2"
   },
   "devDependencies": {
     "expect": "^24.9.0",

--- a/test/parsedQueries/sparqlstar-annotated/sparql-star-annotated-1.json
+++ b/test/parsedQueries/sparqlstar-annotated/sparql-star-annotated-1.json
@@ -38,6 +38,10 @@
             "object": {
               "termType": "Variable",
               "value": "o"
+            },
+            "graph": {
+              "termType": "DefaultGraph",
+              "value": ""
             }
           },
           "predicate": {
@@ -77,6 +81,10 @@
             "object": {
               "termType": "NamedNode",
               "value": "http://example.com/City"
+            },
+            "graph": {
+              "termType": "DefaultGraph",
+              "value": ""
             }
           },
           "predicate": {
@@ -116,6 +124,10 @@
             "object": {
               "termType": "NamedNode",
               "value": "http://www.w3.org/1999/02/22-rdf-syntax-ns#nil"
+            },
+            "graph": {
+              "termType": "DefaultGraph",
+              "value": ""
             }
           },
           "predicate": {

--- a/test/parsedQueries/sparqlstar-annotated/sparql-star-annotated-list-object.json
+++ b/test/parsedQueries/sparqlstar-annotated/sparql-star-annotated-list-object.json
@@ -54,6 +54,10 @@
               "termType": "Variable",
               "value": "s"
             },
+            "graph": {
+              "termType": "DefaultGraph",
+              "value": ""
+            },
             "termType": "Quad"
           }
         },

--- a/test/parsedQueries/sparqlstar-annotated/sparql-star-annotated-list-subject.json
+++ b/test/parsedQueries/sparqlstar-annotated/sparql-star-annotated-list-subject.json
@@ -54,6 +54,10 @@
               "termType": "BlankNode",
               "value": "g_0"
             },
+            "graph": {
+              "termType": "DefaultGraph",
+              "value": ""
+            },
             "termType": "Quad"
           }
         },

--- a/test/parsedQueries/sparqlstar-annotated/sparql-star-annotated-object-list.json
+++ b/test/parsedQueries/sparqlstar-annotated/sparql-star-annotated-object-list.json
@@ -39,6 +39,10 @@
             "object": {
               "termType": "Variable",
               "value": "o1"
+            },
+            "graph": {
+              "termType": "DefaultGraph",
+              "value": ""
             }
           },
           "predicate": {
@@ -78,6 +82,10 @@
             "object": {
               "termType": "Variable",
               "value": "o2"
+            },
+            "graph": {
+              "termType": "DefaultGraph",
+              "value": ""
             }
           },
           "predicate": {
@@ -117,6 +125,10 @@
             "object": {
               "termType": "Variable",
               "value": "o3"
+            },
+            "graph": {
+              "termType": "DefaultGraph",
+              "value": ""
             }
           },
           "predicate": {

--- a/test/parsedQueries/sparqlstar-annotated/sparql-star-annotated-path.json
+++ b/test/parsedQueries/sparqlstar-annotated/sparql-star-annotated-path.json
@@ -49,6 +49,10 @@
               "termType": "Variable",
               "value": "s"
             },
+            "graph": {
+              "termType": "DefaultGraph",
+              "value": ""
+            },
             "termType": "Quad"
           }
         },
@@ -93,7 +97,15 @@
                 "termType": "Variable",
                 "value": "s"
               },
+              "graph": {
+                "termType": "DefaultGraph",
+                "value": ""
+              },
               "termType": "Quad"
+            },
+            "graph": {
+              "termType": "DefaultGraph",
+              "value": ""
             },
             "termType": "Quad"
           }

--- a/test/parsedQueries/sparqlstar-annotated/sparql-star-annotated-semicolon.json
+++ b/test/parsedQueries/sparqlstar-annotated/sparql-star-annotated-semicolon.json
@@ -39,6 +39,10 @@
             "object": {
               "termType": "Variable",
               "value": "o1"
+            },
+            "graph": {
+              "termType": "DefaultGraph",
+              "value": ""
             }
           },
           "predicate": {
@@ -78,6 +82,10 @@
             "object": {
               "termType": "Variable",
               "value": "o2"
+            },
+            "graph": {
+              "termType": "DefaultGraph",
+              "value": ""
             }
           },
           "predicate": {
@@ -117,6 +125,10 @@
             "object": {
               "termType": "Variable",
               "value": "o3"
+            },
+            "graph": {
+              "termType": "DefaultGraph",
+              "value": ""
             }
           },
           "predicate": {

--- a/test/parsedQueries/sparqlstar-annotated/sparql-star-annotated.json
+++ b/test/parsedQueries/sparqlstar-annotated/sparql-star-annotated.json
@@ -38,6 +38,10 @@
             "object": {
               "termType": "Variable",
               "value": "o1"
+            },
+            "graph": {
+              "termType": "DefaultGraph",
+              "value": ""
             }
           },
           "predicate": {
@@ -77,6 +81,10 @@
             "object": {
               "termType": "Variable",
               "value": "o2"
+            },
+            "graph": {
+              "termType": "DefaultGraph",
+              "value": ""
             }
           },
           "predicate": {
@@ -116,6 +124,10 @@
             "object": {
               "termType": "Variable",
               "value": "o1"
+            },
+            "graph": {
+              "termType": "DefaultGraph",
+              "value": ""
             }
           },
           "predicate": {
@@ -155,6 +167,10 @@
             "object": {
               "termType": "Variable",
               "value": "o2"
+            },
+            "graph": {
+              "termType": "DefaultGraph",
+              "value": ""
             }
           },
           "predicate": {

--- a/test/parsedQueries/sparqlstar-annotated/sparql-star-nested-annotated-1.json
+++ b/test/parsedQueries/sparqlstar-annotated/sparql-star-nested-annotated-1.json
@@ -38,6 +38,10 @@
             "object": {
               "termType": "Variable",
               "value": "o1"
+            },
+            "graph": {
+              "termType": "DefaultGraph",
+              "value": ""
             }
           },
           "predicate": {

--- a/test/parsedQueries/sparqlstar-annotated/sparql-star-nested-annotated-10.json
+++ b/test/parsedQueries/sparqlstar-annotated/sparql-star-nested-annotated-10.json
@@ -29,6 +29,10 @@
         "object": {
           "termType": "Variable",
           "value": "o1"
+        },
+        "graph": {
+          "termType": "DefaultGraph",
+          "value": ""
         }
       },
       "predicate": {

--- a/test/parsedQueries/sparqlstar-annotated/sparql-star-nested-annotated-11.json
+++ b/test/parsedQueries/sparqlstar-annotated/sparql-star-nested-annotated-11.json
@@ -48,6 +48,10 @@
             "object": {
               "termType": "Variable",
               "value": "o1"
+            },
+            "graph": {
+              "termType": "DefaultGraph",
+              "value": ""
             }
           },
           "predicate": {

--- a/test/parsedQueries/sparqlstar-annotated/sparql-star-nested-annotated-2.json
+++ b/test/parsedQueries/sparqlstar-annotated/sparql-star-nested-annotated-2.json
@@ -24,6 +24,10 @@
             "object": {
               "termType": "Variable",
               "value": "o0"
+            },
+            "graph": {
+              "termType": "DefaultGraph",
+              "value": ""
             }
           },
           "predicate": {
@@ -51,6 +55,10 @@
               "object": {
                 "termType": "Variable",
                 "value": "o0"
+              },
+              "graph": {
+                "termType": "DefaultGraph",
+                "value": ""
               }
             },
             "predicate": {
@@ -60,6 +68,10 @@
             "object": {
               "termType": "Variable",
               "value": "o1"
+            },
+            "graph": {
+              "termType": "DefaultGraph",
+              "value": ""
             }
           },
           "predicate": {

--- a/test/parsedQueries/sparqlstar-annotated/sparql-star-nested-annotated-3.json
+++ b/test/parsedQueries/sparqlstar-annotated/sparql-star-nested-annotated-3.json
@@ -24,6 +24,10 @@
             "object": {
               "termType": "Variable",
               "value": "o0"
+            },
+            "graph": {
+              "termType": "DefaultGraph",
+              "value": ""
             }
           },
           "predicate": {
@@ -51,6 +55,10 @@
               "object": {
                 "termType": "Variable",
                 "value": "o0"
+              },
+              "graph": {
+                "termType": "DefaultGraph",
+                "value": ""
               }
             },
             "predicate": {
@@ -60,6 +68,10 @@
             "object": {
               "termType": "Variable",
               "value": "o1"
+            },
+            "graph": {
+              "termType": "DefaultGraph",
+              "value": ""
             }
           },
           "predicate": {
@@ -79,6 +91,10 @@
             "object": {
               "termType": "Variable",
               "value": "o3"
+            },
+            "graph": {
+              "termType": "DefaultGraph",
+              "value": ""
             }
           }
         }

--- a/test/parsedQueries/sparqlstar-annotated/sparql-star-nested-annotated-4.json
+++ b/test/parsedQueries/sparqlstar-annotated/sparql-star-nested-annotated-4.json
@@ -24,6 +24,10 @@
             "object": {
               "termType": "Variable",
               "value": "o0"
+            },
+            "graph": {
+              "termType": "DefaultGraph",
+              "value": ""
             }
           },
           "predicate": {
@@ -43,6 +47,10 @@
             "object": {
               "termType": "Variable",
               "value": "o2"
+            },
+            "graph": {
+              "termType": "DefaultGraph",
+              "value": ""
             }
           }
         },
@@ -62,6 +70,10 @@
               "object": {
                 "termType": "Variable",
                 "value": "o0"
+              },
+              "graph": {
+                "termType": "DefaultGraph",
+                "value": ""
               }
             },
             "predicate": {
@@ -81,7 +93,15 @@
               "object": {
                 "termType": "Variable",
                 "value": "o2"
+              },
+              "graph": {
+                "termType": "DefaultGraph",
+                "value": ""
               }
+            },
+            "graph": {
+              "termType": "DefaultGraph",
+              "value": ""
             }
           },
           "predicate": {
@@ -101,6 +121,10 @@
             "object": {
               "termType": "Variable",
               "value": "o3"
+            },
+            "graph": {
+              "termType": "DefaultGraph",
+              "value": ""
             }
           }
         }

--- a/test/parsedQueries/sparqlstar-annotated/sparql-star-nested-annotated-5.json
+++ b/test/parsedQueries/sparqlstar-annotated/sparql-star-nested-annotated-5.json
@@ -34,7 +34,15 @@
               "object": {
                 "termType": "Variable",
                 "value": "o2"
+              },
+              "graph": {
+                "termType": "DefaultGraph",
+                "value": ""
               }
+            },
+            "graph": {
+              "termType": "DefaultGraph",
+              "value": ""
             }
           },
           "predicate": {
@@ -72,7 +80,15 @@
                 "object": {
                   "termType": "Variable",
                   "value": "o2"
+                },
+                "graph": {
+                  "termType": "DefaultGraph",
+                  "value": ""
                 }
+              },
+              "graph": {
+                "termType": "DefaultGraph",
+                "value": ""
               }
             },
             "predicate": {
@@ -82,6 +98,10 @@
             "object": {
               "termType": "Variable",
               "value": "p1"
+            },
+            "graph": {
+              "termType": "DefaultGraph",
+              "value": ""
             }
           },
           "predicate": {
@@ -111,7 +131,15 @@
               "object": {
                 "termType": "Variable",
                 "value": "o4"
+              },
+              "graph": {
+                "termType": "DefaultGraph",
+                "value": ""
               }
+            },
+            "graph": {
+              "termType": "DefaultGraph",
+              "value": ""
             }
           }
         }

--- a/test/parsedQueries/sparqlstar-annotated/sparql-star-nested-annotated-6.json
+++ b/test/parsedQueries/sparqlstar-annotated/sparql-star-nested-annotated-6.json
@@ -38,6 +38,10 @@
             "object": {
               "termType": "Variable",
               "value": "o1"
+            },
+            "graph": {
+              "termType": "DefaultGraph",
+              "value": ""
             }
           },
           "predicate": {
@@ -63,6 +67,10 @@
             "object": {
               "termType": "Variable",
               "value": "o1"
+            },
+            "graph": {
+              "termType": "DefaultGraph",
+              "value": ""
             }
           },
           "predicate": {

--- a/test/parsedQueries/sparqlstar-annotated/sparql-star-nested-annotated-7.json
+++ b/test/parsedQueries/sparqlstar-annotated/sparql-star-nested-annotated-7.json
@@ -38,6 +38,10 @@
             "object": {
               "termType": "Variable",
               "value": "o1"
+            },
+            "graph": {
+              "termType": "DefaultGraph",
+              "value": ""
             }
           },
           "predicate": {
@@ -63,6 +67,10 @@
             "object": {
               "termType": "Variable",
               "value": "o1"
+            },
+            "graph": {
+              "termType": "DefaultGraph",
+              "value": ""
             }
           },
           "predicate": {

--- a/test/parsedQueries/sparqlstar-annotated/sparql-star-nested-annotated-8.json
+++ b/test/parsedQueries/sparqlstar-annotated/sparql-star-nested-annotated-8.json
@@ -38,6 +38,10 @@
             "object": {
               "termType": "Variable",
               "value": "o1"
+            },
+            "graph": {
+              "termType": "DefaultGraph",
+              "value": ""
             }
           },
           "predicate": {
@@ -65,6 +69,10 @@
               "object": {
                 "termType": "Variable",
                 "value": "o1"
+              },
+              "graph": {
+                "termType": "DefaultGraph",
+                "value": ""
               }
             },
             "predicate": {
@@ -74,6 +82,10 @@
             "object": {
               "termType": "Variable",
               "value": "o2"
+            },
+            "graph": {
+              "termType": "DefaultGraph",
+              "value": ""
             }
           },
           "predicate": {

--- a/test/parsedQueries/sparqlstar-annotated/sparql-star-nested-annotated-9.json
+++ b/test/parsedQueries/sparqlstar-annotated/sparql-star-nested-annotated-9.json
@@ -38,6 +38,10 @@
             "object": {
               "termType": "Variable",
               "value": "o1"
+            },
+            "graph": {
+              "termType": "DefaultGraph",
+              "value": ""
             }
           },
           "predicate": {
@@ -65,6 +69,10 @@
               "object": {
                 "termType": "Variable",
                 "value": "o1"
+              },
+              "graph": {
+                "termType": "DefaultGraph",
+                "value": ""
               }
             },
             "predicate": {
@@ -74,6 +82,10 @@
             "object": {
               "termType": "Variable",
               "value": "o2"
+            },
+            "graph": {
+              "termType": "DefaultGraph",
+              "value": ""
             }
           },
           "predicate": {
@@ -103,6 +115,10 @@
                 "object": {
                   "termType": "Variable",
                   "value": "o1"
+                },
+                "graph": {
+                  "termType": "DefaultGraph",
+                  "value": ""
                 }
               },
               "predicate": {
@@ -112,6 +128,10 @@
               "object": {
                 "termType": "Variable",
                 "value": "o2"
+              },
+              "graph": {
+                "termType": "DefaultGraph",
+                "value": ""
               }
             },
             "predicate": {
@@ -121,6 +141,10 @@
             "object": {
               "termType": "Variable",
               "value": "o3"
+            },
+            "graph": {
+              "termType": "DefaultGraph",
+              "value": ""
             }
           },
           "predicate": {

--- a/test/parsedQueries/sparqlstar-spec/sparql-star-annotation-01.json
+++ b/test/parsedQueries/sparqlstar-spec/sparql-star-annotation-01.json
@@ -38,6 +38,10 @@
             "object": {
               "termType": "Variable",
               "value": "o"
+            },
+            "graph": {
+              "termType": "DefaultGraph",
+              "value": ""
             }
           },
           "predicate": {

--- a/test/parsedQueries/sparqlstar-spec/sparql-star-annotation-02.json
+++ b/test/parsedQueries/sparqlstar-spec/sparql-star-annotation-02.json
@@ -38,6 +38,10 @@
             "object": {
               "termType": "NamedNode",
               "value": "http://example.com/ns#o"
+            },
+            "graph": {
+              "termType": "DefaultGraph",
+              "value": ""
             }
           },
           "predicate": {
@@ -63,6 +67,10 @@
             "object": {
               "termType": "NamedNode",
               "value": "http://example.com/ns#o"
+            },
+            "graph": {
+              "termType": "DefaultGraph",
+              "value": ""
             }
           },
           "predicate": {

--- a/test/parsedQueries/sparqlstar-spec/sparql-star-annotation-03.json
+++ b/test/parsedQueries/sparqlstar-spec/sparql-star-annotation-03.json
@@ -32,6 +32,10 @@
             "object": {
               "termType": "NamedNode",
               "value": "http://example.com/ns#c"
+            },
+            "graph": {
+              "termType": "DefaultGraph",
+              "value": ""
             }
           }
         },
@@ -59,7 +63,15 @@
               "object": {
                 "termType": "NamedNode",
                 "value": "http://example.com/ns#c"
+              },
+              "graph": {
+                "termType": "DefaultGraph",
+                "value": ""
               }
+            },
+            "graph": {
+              "termType": "DefaultGraph",
+              "value": ""
             }
           },
           "predicate": {

--- a/test/parsedQueries/sparqlstar-spec/sparql-star-annotation-04.json
+++ b/test/parsedQueries/sparqlstar-spec/sparql-star-annotation-04.json
@@ -32,6 +32,10 @@
             "object": {
               "termType": "NamedNode",
               "value": "http://example.com/ns#c"
+            },
+            "graph": {
+              "termType": "DefaultGraph",
+              "value": ""
             }
           }
         },
@@ -59,7 +63,15 @@
               "object": {
                 "termType": "NamedNode",
                 "value": "http://example.com/ns#c"
+              },
+              "graph": {
+                "termType": "DefaultGraph",
+                "value": ""
               }
+            },
+            "graph": {
+              "termType": "DefaultGraph",
+              "value": ""
             }
           },
           "predicate": {
@@ -79,6 +91,10 @@
             "object": {
               "termType": "Variable",
               "value": "z"
+            },
+            "graph": {
+              "termType": "DefaultGraph",
+              "value": ""
             }
           }
         }

--- a/test/parsedQueries/sparqlstar-spec/sparql-star-annotation-05.json
+++ b/test/parsedQueries/sparqlstar-spec/sparql-star-annotation-05.json
@@ -24,6 +24,10 @@
             "object": {
               "termType": "NamedNode",
               "value": "http://example.com/ns#o1"
+            },
+            "graph": {
+              "termType": "DefaultGraph",
+              "value": ""
             }
           },
           "predicate": {
@@ -51,6 +55,10 @@
               "object": {
                 "termType": "NamedNode",
                 "value": "http://example.com/ns#o1"
+              },
+              "graph": {
+                "termType": "DefaultGraph",
+                "value": ""
               }
             },
             "predicate": {
@@ -60,6 +68,10 @@
             "object": {
               "termType": "Variable",
               "value": "o"
+            },
+            "graph": {
+              "termType": "DefaultGraph",
+              "value": ""
             }
           },
           "predicate": {

--- a/test/parsedQueries/sparqlstar-spec/sparql-star-annotation-06.json
+++ b/test/parsedQueries/sparqlstar-spec/sparql-star-annotation-06.json
@@ -38,6 +38,10 @@
             "object": {
               "termType": "Variable",
               "value": "o"
+            },
+            "graph": {
+              "termType": "DefaultGraph",
+              "value": ""
             }
           },
           "predicate": {

--- a/test/parsedQueries/sparqlstar-spec/sparql-star-annotation-07.json
+++ b/test/parsedQueries/sparqlstar-spec/sparql-star-annotation-07.json
@@ -38,6 +38,10 @@
             "object": {
               "termType": "Variable",
               "value": "o"
+            },
+            "graph": {
+              "termType": "DefaultGraph",
+              "value": ""
             }
           },
           "predicate": {

--- a/test/parsedQueries/sparqlstar-spec/sparql-star-annotation-08.json
+++ b/test/parsedQueries/sparqlstar-spec/sparql-star-annotation-08.json
@@ -29,6 +29,10 @@
         "object": {
           "termType": "Variable",
           "value": "o"
+        },
+        "graph": {
+          "termType": "DefaultGraph",
+          "value": ""
         }
       },
       "predicate": {

--- a/test/parsedQueries/sparqlstar-spec/sparql-star-annotation-09.json
+++ b/test/parsedQueries/sparqlstar-spec/sparql-star-annotation-09.json
@@ -29,6 +29,10 @@
         "object": {
           "termType": "Variable",
           "value": "o"
+        },
+        "graph": {
+          "termType": "DefaultGraph",
+          "value": ""
         }
       },
       "predicate": {
@@ -73,6 +77,10 @@
             "object": {
               "termType": "Variable",
               "value": "o"
+            },
+            "graph": {
+              "termType": "DefaultGraph",
+              "value": ""
             }
           },
           "predicate": {

--- a/test/parsedQueries/sparqlstar-spec/sparql-star-syntax-basic-01.json
+++ b/test/parsedQueries/sparqlstar-spec/sparql-star-syntax-basic-01.json
@@ -24,6 +24,10 @@
             "object": {
               "termType": "NamedNode",
               "value": "http://example.com/ns#c"
+            },
+            "graph": {
+              "termType": "DefaultGraph",
+              "value": ""
             }
           },
           "predicate": {

--- a/test/parsedQueries/sparqlstar-spec/sparql-star-syntax-basic-02.json
+++ b/test/parsedQueries/sparqlstar-spec/sparql-star-syntax-basic-02.json
@@ -37,6 +37,10 @@
                 "termType": "NamedNode",
                 "value": "http://www.w3.org/2001/XMLSchema#string"
               }
+            },
+            "graph": {
+              "termType": "DefaultGraph",
+              "value": ""
             }
           }
         }

--- a/test/parsedQueries/sparqlstar-spec/sparql-star-syntax-basic-03.json
+++ b/test/parsedQueries/sparqlstar-spec/sparql-star-syntax-basic-03.json
@@ -24,6 +24,10 @@
             "object": {
               "termType": "Variable",
               "value": "o"
+            },
+            "graph": {
+              "termType": "DefaultGraph",
+              "value": ""
             }
           },
           "predicate": {

--- a/test/parsedQueries/sparqlstar-spec/sparql-star-syntax-basic-04.json
+++ b/test/parsedQueries/sparqlstar-spec/sparql-star-syntax-basic-04.json
@@ -32,6 +32,10 @@
             "object": {
               "termType": "Variable",
               "value": "c"
+            },
+            "graph": {
+              "termType": "DefaultGraph",
+              "value": ""
             }
           }
         }

--- a/test/parsedQueries/sparqlstar-spec/sparql-star-syntax-basic-05.json
+++ b/test/parsedQueries/sparqlstar-spec/sparql-star-syntax-basic-05.json
@@ -24,6 +24,10 @@
             "object": {
               "termType": "NamedNode",
               "value": "http://example.com/ns#o"
+            },
+            "graph": {
+              "termType": "DefaultGraph",
+              "value": ""
             }
           }
         },
@@ -43,6 +47,10 @@
               "object": {
                 "termType": "NamedNode",
                 "value": "http://example.com/ns#o"
+              },
+              "graph": {
+                "termType": "DefaultGraph",
+                "value": ""
               }
             },
             "predicate": {
@@ -52,6 +60,10 @@
             "object": {
               "termType": "NamedNode",
               "value": "http://example.com/ns#z"
+            },
+            "graph": {
+              "termType": "DefaultGraph",
+              "value": ""
             }
           }
         }
@@ -74,6 +86,10 @@
             "object": {
               "termType": "NamedNode",
               "value": "http://example.com/ns#o"
+            },
+            "graph": {
+              "termType": "DefaultGraph",
+              "value": ""
             }
           },
           "?z": {
@@ -109,6 +125,10 @@
             "object": {
               "termType": "NamedNode",
               "value": "http://example.com/ns#o"
+            },
+            "graph": {
+              "termType": "DefaultGraph",
+              "value": ""
             }
           }
         }

--- a/test/parsedQueries/sparqlstar-spec/sparql-star-syntax-basic-06.json
+++ b/test/parsedQueries/sparqlstar-spec/sparql-star-syntax-basic-06.json
@@ -15,6 +15,10 @@
         "object": {
           "termType": "NamedNode",
           "value": "http://example.com/ns#o"
+        },
+        "graph": {
+          "termType": "DefaultGraph",
+          "value": ""
         }
       },
       "predicate": {

--- a/test/parsedQueries/sparqlstar-spec/sparql-star-syntax-basic-07.json
+++ b/test/parsedQueries/sparqlstar-spec/sparql-star-syntax-basic-07.json
@@ -15,6 +15,10 @@
         "object": {
           "termType": "Variable",
           "value": "o"
+        },
+        "graph": {
+          "termType": "DefaultGraph",
+          "value": ""
         }
       },
       "predicate": {
@@ -48,6 +52,10 @@
         "object": {
           "termType": "Variable",
           "value": "o"
+        },
+        "graph": {
+          "termType": "DefaultGraph",
+          "value": ""
         }
       }
     }
@@ -70,6 +78,10 @@
             "object": {
               "termType": "Variable",
               "value": "o"
+            },
+            "graph": {
+              "termType": "DefaultGraph",
+              "value": ""
             }
           },
           "predicate": {
@@ -103,6 +115,10 @@
             "object": {
               "termType": "Variable",
               "value": "o"
+            },
+            "graph": {
+              "termType": "DefaultGraph",
+              "value": ""
             }
           }
         }

--- a/test/parsedQueries/sparqlstar-spec/sparql-star-syntax-bnode-01.json
+++ b/test/parsedQueries/sparqlstar-spec/sparql-star-syntax-bnode-01.json
@@ -24,6 +24,10 @@
             "object": {
               "termType": "NamedNode",
               "value": "http://example.com/ns#o"
+            },
+            "graph": {
+              "termType": "DefaultGraph",
+              "value": ""
             }
           },
           "predicate": {

--- a/test/parsedQueries/sparqlstar-spec/sparql-star-syntax-bnode-02.json
+++ b/test/parsedQueries/sparqlstar-spec/sparql-star-syntax-bnode-02.json
@@ -24,6 +24,10 @@
             "object": {
               "termType": "BlankNode",
               "value": "e_a"
+            },
+            "graph": {
+              "termType": "DefaultGraph",
+              "value": ""
             }
           },
           "predicate": {

--- a/test/parsedQueries/sparqlstar-spec/sparql-star-syntax-bnode-03.json
+++ b/test/parsedQueries/sparqlstar-spec/sparql-star-syntax-bnode-03.json
@@ -24,6 +24,10 @@
             "object": {
               "termType": "BlankNode",
               "value": "g_1"
+            },
+            "graph": {
+              "termType": "DefaultGraph",
+              "value": ""
             }
           },
           "predicate": {

--- a/test/parsedQueries/sparqlstar-spec/sparql-star-syntax-compound.json
+++ b/test/parsedQueries/sparqlstar-spec/sparql-star-syntax-compound.json
@@ -24,6 +24,10 @@
             "object": {
               "termType": "NamedNode",
               "value": "http://example.com/ns#z"
+            },
+            "graph": {
+              "termType": "DefaultGraph",
+              "value": ""
             }
           },
           "predicate": {
@@ -43,6 +47,10 @@
             "object": {
               "termType": "Variable",
               "value": "C"
+            },
+            "graph": {
+              "termType": "DefaultGraph",
+              "value": ""
             }
           }
         },
@@ -62,6 +70,10 @@
               "object": {
                 "termType": "NamedNode",
                 "value": "http://example.com/ns#z"
+              },
+              "graph": {
+                "termType": "DefaultGraph",
+                "value": ""
               }
             },
             "predicate": {
@@ -81,7 +93,15 @@
               "object": {
                 "termType": "BlankNode",
                 "value": "g_0"
+              },
+              "graph": {
+                "termType": "DefaultGraph",
+                "value": ""
               }
+            },
+            "graph": {
+              "termType": "DefaultGraph",
+              "value": ""
             }
           },
           "predicate": {
@@ -103,6 +123,10 @@
               "object": {
                 "termType": "NamedNode",
                 "value": "http://example.com/ns#z"
+              },
+              "graph": {
+                "termType": "DefaultGraph",
+                "value": ""
               }
             },
             "predicate": {
@@ -122,7 +146,15 @@
               "object": {
                 "termType": "BlankNode",
                 "value": "g_2"
+              },
+              "graph": {
+                "termType": "DefaultGraph",
+                "value": ""
               }
+            },
+            "graph": {
+              "termType": "DefaultGraph",
+              "value": ""
             }
           }
         }

--- a/test/parsedQueries/sparqlstar-spec/sparql-star-syntax-expr-01.json
+++ b/test/parsedQueries/sparqlstar-spec/sparql-star-syntax-expr-01.json
@@ -45,6 +45,10 @@
         "object": {
           "termType": "Variable",
           "value": "o"
+        },
+        "graph": {
+          "termType": "DefaultGraph",
+          "value": ""
         }
       }
     }

--- a/test/parsedQueries/sparqlstar-spec/sparql-star-syntax-expr-02.json
+++ b/test/parsedQueries/sparqlstar-spec/sparql-star-syntax-expr-02.json
@@ -47,6 +47,10 @@
           "object": {
             "termType": "Variable",
             "value": "o"
+          },
+          "graph": {
+            "termType": "DefaultGraph",
+            "value": ""
           }
         },
         "predicate": {
@@ -56,6 +60,10 @@
         "object": {
           "termType": "NamedNode",
           "value": "http://example.com/ns#z"
+        },
+        "graph": {
+          "termType": "DefaultGraph",
+          "value": ""
         }
       }
     }

--- a/test/parsedQueries/sparqlstar-spec/sparql-star-syntax-expr-06.json
+++ b/test/parsedQueries/sparqlstar-spec/sparql-star-syntax-expr-06.json
@@ -58,6 +58,10 @@
             "object": {
               "termType": "Variable",
               "value": "o"
+            },
+            "graph": {
+              "termType": "DefaultGraph",
+              "value": ""
             }
           }
         }

--- a/test/parsedQueries/sparqlstar-spec/sparql-star-syntax-inside-01.json
+++ b/test/parsedQueries/sparqlstar-spec/sparql-star-syntax-inside-01.json
@@ -46,6 +46,10 @@
             "object": {
               "termType": "NamedNode",
               "value": "http://example.com/ns#o"
+            },
+            "graph": {
+              "termType": "DefaultGraph",
+              "value": ""
             }
           }
         }

--- a/test/parsedQueries/sparqlstar-spec/sparql-star-syntax-inside-02.json
+++ b/test/parsedQueries/sparqlstar-spec/sparql-star-syntax-inside-02.json
@@ -51,6 +51,10 @@
             "object": {
               "termType": "NamedNode",
               "value": "http://example.com/ns#o1"
+            },
+            "graph": {
+              "termType": "DefaultGraph",
+              "value": ""
             }
           }
         },
@@ -90,6 +94,10 @@
             "object": {
               "termType": "NamedNode",
               "value": "http://example.com/ns#o2"
+            },
+            "graph": {
+              "termType": "DefaultGraph",
+              "value": ""
             }
           }
         },

--- a/test/parsedQueries/sparqlstar-spec/sparql-star-syntax-nested-01.json
+++ b/test/parsedQueries/sparqlstar-spec/sparql-star-syntax-nested-01.json
@@ -24,6 +24,10 @@
             "object": {
               "termType": "NamedNode",
               "value": "http://example.com/ns#o"
+            },
+            "graph": {
+              "termType": "DefaultGraph",
+              "value": ""
             }
           },
           "predicate": {
@@ -51,6 +55,10 @@
               "object": {
                 "termType": "NamedNode",
                 "value": "http://example.com/ns#o"
+              },
+              "graph": {
+                "termType": "DefaultGraph",
+                "value": ""
               }
             },
             "predicate": {
@@ -60,6 +68,10 @@
             "object": {
               "termType": "NamedNode",
               "value": "http://example.com/ns#z"
+            },
+            "graph": {
+              "termType": "DefaultGraph",
+              "value": ""
             }
           },
           "predicate": {

--- a/test/parsedQueries/sparqlstar-spec/sparql-star-syntax-nested-02.json
+++ b/test/parsedQueries/sparqlstar-spec/sparql-star-syntax-nested-02.json
@@ -32,6 +32,10 @@
             "object": {
               "termType": "Variable",
               "value": "O"
+            },
+            "graph": {
+              "termType": "DefaultGraph",
+              "value": ""
             }
           }
         },
@@ -59,7 +63,15 @@
               "object": {
                 "termType": "Variable",
                 "value": "O"
+              },
+              "graph": {
+                "termType": "DefaultGraph",
+                "value": ""
               }
+            },
+            "graph": {
+              "termType": "DefaultGraph",
+              "value": ""
             }
           },
           "predicate": {

--- a/test/parsedQueries/sparqlstar-spec/sparql-star-syntax-update-1.json
+++ b/test/parsedQueries/sparqlstar-spec/sparql-star-syntax-update-1.json
@@ -21,6 +21,10 @@
                 "object": {
                   "termType": "NamedNode",
                   "value": "http://example.com/ns#c"
+                },
+                "graph": {
+                  "termType": "DefaultGraph",
+                  "value": ""
                 }
               },
               "predicate": {

--- a/test/parsedQueries/sparqlstar-spec/sparql-star-syntax-update-2.json
+++ b/test/parsedQueries/sparqlstar-spec/sparql-star-syntax-update-2.json
@@ -35,6 +35,10 @@
                 "object": {
                   "termType": "NamedNode",
                   "value": "http://example.com/ns#o"
+                },
+                "graph": {
+                  "termType": "DefaultGraph",
+                  "value": ""
                 }
               },
               "predicate": {

--- a/test/parsedQueries/sparqlstar-spec/sparql-star-syntax-update-3.json
+++ b/test/parsedQueries/sparqlstar-spec/sparql-star-syntax-update-3.json
@@ -22,6 +22,10 @@
                 "object": {
                   "termType": "NamedNode",
                   "value": "http://example.com/ns#c"
+                },
+                "graph": {
+                  "termType": "DefaultGraph",
+                  "value": ""
                 }
               },
               "predicate": {
@@ -49,6 +53,10 @@
                   "object": {
                     "termType": "NamedNode",
                     "value": "http://example.com/ns#c"
+                  },
+                  "graph": {
+                    "termType": "DefaultGraph",
+                    "value": ""
                   }
                 },
                 "predicate": {
@@ -58,6 +66,10 @@
                 "object": {
                   "termType": "NamedNode",
                   "value": "http://example.com/ns#o2"
+                },
+                "graph": {
+                  "termType": "DefaultGraph",
+                  "value": ""
                 }
               },
               "predicate": {
@@ -90,6 +102,10 @@
                 "object": {
                   "termType": "NamedNode",
                   "value": "http://example.com/ns#c"
+                },
+                "graph": {
+                  "termType": "DefaultGraph",
+                  "value": ""
                 }
               },
               "predicate": {
@@ -117,6 +133,10 @@
                   "object": {
                     "termType": "NamedNode",
                     "value": "http://example.com/ns#c"
+                  },
+                  "graph": {
+                    "termType": "DefaultGraph",
+                    "value": ""
                   }
                 },
                 "predicate": {
@@ -126,6 +146,10 @@
                 "object": {
                   "termType": "NamedNode",
                   "value": "http://example.com/ns#o1"
+                },
+                "graph": {
+                  "termType": "DefaultGraph",
+                  "value": ""
                 }
               },
               "predicate": {

--- a/test/parsedQueries/sparqlstar-spec/sparql-star-syntax-update-4.json
+++ b/test/parsedQueries/sparqlstar-spec/sparql-star-syntax-update-4.json
@@ -22,6 +22,10 @@
                 "object": {
                   "termType": "NamedNode",
                   "value": "http://example.com/ns#c"
+                },
+                "graph": {
+                  "termType": "DefaultGraph",
+                  "value": ""
                 }
               },
               "predicate": {
@@ -49,6 +53,10 @@
                   "object": {
                     "termType": "NamedNode",
                     "value": "http://example.com/ns#c"
+                  },
+                  "graph": {
+                    "termType": "DefaultGraph",
+                    "value": ""
                   }
                 },
                 "predicate": {
@@ -58,6 +66,10 @@
                 "object": {
                   "termType": "NamedNode",
                   "value": "http://example.com/ns#o2"
+                },
+                "graph": {
+                  "termType": "DefaultGraph",
+                  "value": ""
                 }
               },
               "predicate": {
@@ -77,6 +89,10 @@
                 "object": {
                   "termType": "Variable",
                   "value": "Z"
+                },
+                "graph": {
+                  "termType": "DefaultGraph",
+                  "value": ""
                 }
               }
             }
@@ -101,6 +117,10 @@
                 "object": {
                   "termType": "NamedNode",
                   "value": "http://example.com/ns#c"
+                },
+                "graph": {
+                  "termType": "DefaultGraph",
+                  "value": ""
                 }
               },
               "predicate": {
@@ -128,6 +148,10 @@
                   "object": {
                     "termType": "NamedNode",
                     "value": "http://example.com/ns#c"
+                  },
+                  "graph": {
+                    "termType": "DefaultGraph",
+                    "value": ""
                   }
                 },
                 "predicate": {
@@ -137,6 +161,10 @@
                 "object": {
                   "termType": "NamedNode",
                   "value": "http://example.com/ns#o1"
+                },
+                "graph": {
+                  "termType": "DefaultGraph",
+                  "value": ""
                 }
               },
               "predicate": {
@@ -156,6 +184,10 @@
                 "object": {
                   "termType": "Variable",
                   "value": "Z"
+                },
+                "graph": {
+                  "termType": "DefaultGraph",
+                  "value": ""
                 }
               }
             }

--- a/test/parsedQueries/sparqlstar-spec/sparql-star-syntax-update-5.json
+++ b/test/parsedQueries/sparqlstar-spec/sparql-star-syntax-update-5.json
@@ -30,6 +30,10 @@
                 "object": {
                   "termType": "Variable",
                   "value": "O"
+                },
+                "graph": {
+                  "termType": "DefaultGraph",
+                  "value": ""
                 }
               }
             },
@@ -57,7 +61,15 @@
                   "object": {
                     "termType": "Variable",
                     "value": "O"
+                  },
+                  "graph": {
+                    "termType": "DefaultGraph",
+                    "value": ""
                   }
+                },
+                "graph": {
+                  "termType": "DefaultGraph",
+                  "value": ""
                 }
               },
               "predicate": {
@@ -98,6 +110,10 @@
                 "object": {
                   "termType": "Variable",
                   "value": "O"
+                },
+                "graph": {
+                  "termType": "DefaultGraph",
+                  "value": ""
                 }
               }
             },
@@ -125,7 +141,15 @@
                   "object": {
                     "termType": "Variable",
                     "value": "O"
+                  },
+                  "graph": {
+                    "termType": "DefaultGraph",
+                    "value": ""
                   }
+                },
+                "graph": {
+                  "termType": "DefaultGraph",
+                  "value": ""
                 }
               },
               "predicate": {

--- a/test/parsedQueries/sparqlstar-spec/sparql-star-syntax-update-6.json
+++ b/test/parsedQueries/sparqlstar-spec/sparql-star-syntax-update-6.json
@@ -36,6 +36,10 @@
                 "object": {
                   "termType": "Variable",
                   "value": "o"
+                },
+                "graph": {
+                  "termType": "DefaultGraph",
+                  "value": ""
                 }
               },
               "predicate": {

--- a/test/parsedQueries/sparqlstar-spec/sparql-star-syntax-update-7.json
+++ b/test/parsedQueries/sparqlstar-spec/sparql-star-syntax-update-7.json
@@ -35,6 +35,10 @@
                 "object": {
                   "termType": "Variable",
                   "value": "o"
+                },
+                "graph": {
+                  "termType": "DefaultGraph",
+                  "value": ""
                 }
               },
               "predicate": {
@@ -87,6 +91,10 @@
                 "object": {
                   "termType": "Variable",
                   "value": "o"
+                },
+                "graph": {
+                  "termType": "DefaultGraph",
+                  "value": ""
                 }
               },
               "predicate": {

--- a/test/parsedQueries/sparqlstar-spec/sparql-star-syntax-update-8.json
+++ b/test/parsedQueries/sparqlstar-spec/sparql-star-syntax-update-8.json
@@ -35,6 +35,10 @@
                 "object": {
                   "termType": "NamedNode",
                   "value": "http://example.com/ns#o1"
+                },
+                "graph": {
+                  "termType": "DefaultGraph",
+                  "value": ""
                 }
               },
               "predicate": {
@@ -89,6 +93,10 @@
                 "object": {
                   "termType": "NamedNode",
                   "value": "http://example.com/ns#o2"
+                },
+                "graph": {
+                  "termType": "DefaultGraph",
+                  "value": ""
                 }
               },
               "predicate": {

--- a/test/parsedQueries/sparqlstar/sparql-star-2.json
+++ b/test/parsedQueries/sparqlstar/sparql-star-2.json
@@ -19,6 +19,10 @@
         "object": {
           "termType": "NamedNode",
           "value": "http://example.com/City"
+        },
+        "graph": {
+          "termType": "DefaultGraph",
+          "value": ""
         }
       },
       "variable": {
@@ -47,6 +51,10 @@
         "object": {
           "termType": "NamedNode",
           "value": "http://example.com/City"
+        },
+        "graph": {
+          "termType": "DefaultGraph",
+          "value": ""
         }
       }
     }

--- a/test/parsedQueries/sparqlstar/sparql-star-bind-nested-1.json
+++ b/test/parsedQueries/sparqlstar/sparql-star-bind-nested-1.json
@@ -27,6 +27,10 @@
           "object": {
             "termType": "NamedNode",
             "value": "http://example.com/City"
+          },
+          "graph": {
+            "termType": "DefaultGraph",
+            "value": ""
           }
         },
         "predicate": {
@@ -36,6 +40,10 @@
         "object": {
           "termType": "NamedNode",
           "value": "http://example.com/b"
+        },
+        "graph": {
+          "termType": "DefaultGraph",
+          "value": ""
         }
       }
     }

--- a/test/parsedQueries/sparqlstar/sparql-star-bind-nested-2.json
+++ b/test/parsedQueries/sparqlstar/sparql-star-bind-nested-2.json
@@ -36,7 +36,15 @@
           "object": {
             "termType": "NamedNode",
             "value": "http://example.com/City"
+          },
+          "graph": {
+            "termType": "DefaultGraph",
+            "value": ""
           }
+        },
+        "graph": {
+          "termType": "DefaultGraph",
+          "value": ""
         }
       }
     }

--- a/test/parsedQueries/sparqlstar/sparql-star-bind-var.json
+++ b/test/parsedQueries/sparqlstar/sparql-star-bind-var.json
@@ -15,6 +15,10 @@
         "object": {
           "termType": "Variable",
           "value": "c"
+        },
+        "graph": {
+          "termType": "DefaultGraph",
+          "value": ""
         }
       },
       "variable": {
@@ -47,6 +51,10 @@
         "object": {
           "termType": "Variable",
           "value": "o"
+        },
+        "graph": {
+          "termType": "DefaultGraph",
+          "value": ""
         }
       }
     }

--- a/test/parsedQueries/sparqlstar/sparql-star-bind.json
+++ b/test/parsedQueries/sparqlstar/sparql-star-bind.json
@@ -25,6 +25,10 @@
         "object": {
           "termType": "NamedNode",
           "value": "http://example.com/City"
+        },
+        "graph": {
+          "termType": "DefaultGraph",
+          "value": ""
         }
       }
     }

--- a/test/parsedQueries/sparqlstar/sparql-star-nested-1.json
+++ b/test/parsedQueries/sparqlstar/sparql-star-nested-1.json
@@ -25,6 +25,10 @@
                 "object": {
                   "termType": "Variable",
                   "value": "o1"
+                },
+                "graph": {
+                  "termType": "DefaultGraph",
+                  "value": ""
                 }
               },
               "predicate": {
@@ -34,7 +38,11 @@
               "object": {
                 "termType": "Variable",
                 "value": "o2"
-              }
+              },
+            "graph": {
+              "termType": "DefaultGraph",
+              "value": ""
+            }
           },
           "predicate": {
             "termType": "Variable",

--- a/test/parsedQueries/sparqlstar/sparql-star-nested-2.json
+++ b/test/parsedQueries/sparqlstar/sparql-star-nested-2.json
@@ -41,7 +41,15 @@
               "object": {
                 "termType": "Variable",
                 "value": "o3"
+              },
+              "graph": {
+                "termType": "DefaultGraph",
+                "value": ""
               }
+            },
+            "graph": {
+              "termType": "DefaultGraph",
+              "value": ""
             }
           }
         }

--- a/test/parsedQueries/sparqlstar/sparql-star-select-bind-nested-1.json
+++ b/test/parsedQueries/sparqlstar/sparql-star-select-bind-nested-1.json
@@ -21,6 +21,10 @@
           "object": {
             "termType": "NamedNode",
             "value": "http://example.com/City"
+          },
+          "graph": {
+            "termType": "DefaultGraph",
+            "value": ""
           }
         },
         "predicate": {
@@ -30,6 +34,10 @@
         "object": {
           "termType": "NamedNode",
           "value": "http://example.com/b"
+        },
+        "graph": {
+          "termType": "DefaultGraph",
+          "value": ""
         }
       },
       "variable": {

--- a/test/parsedQueries/sparqlstar/sparql-star-select-bind-nested-2.json
+++ b/test/parsedQueries/sparqlstar/sparql-star-select-bind-nested-2.json
@@ -29,7 +29,15 @@
           "object": {
             "termType": "NamedNode",
             "value": "http://example.com/c"
+          },
+          "graph": {
+            "termType": "DefaultGraph",
+            "value": ""
           }
+        },
+        "graph": {
+          "termType": "DefaultGraph",
+          "value": ""
         }
       },
       "variable": {

--- a/test/parsedQueries/sparqlstar/sparql-star-select-bind.json
+++ b/test/parsedQueries/sparqlstar/sparql-star-select-bind.json
@@ -19,6 +19,10 @@
         "object": {
           "termType": "NamedNode",
           "value": "http://example.com/City"
+        },
+        "graph": {
+          "termType": "DefaultGraph",
+          "value": ""
         }
       },
       "variable": {

--- a/test/parsedQueries/sparqlstar/sparql-star-values.json
+++ b/test/parsedQueries/sparqlstar/sparql-star-values.json
@@ -24,6 +24,10 @@
             "object": {
               "termType": "NamedNode",
               "value": "http://example.com/City"
+            },
+            "graph": {
+              "termType": "DefaultGraph",
+              "value": ""
             }
           }
         },
@@ -51,7 +55,15 @@
               "object": {
                 "termType": "NamedNode",
                 "value": "http://example.com/City"
+              },
+              "graph": {
+                "termType": "DefaultGraph",
+                "value": ""
               }
+            },
+            "graph": {
+              "termType": "DefaultGraph",
+              "value": ""
             }
           }
         }


### PR DESCRIPTION
The `graph` field is always required in `Quad` objects according to RDF/JS. Not having it can cause crashes (which is what is happening in SPARQLAlgebra.js because of this bug).