### PR TITLE
Make exports compatible with ES modules

### DIFF
--- a/lib/SparqlGenerator.js
+++ b/lib/SparqlGenerator.js
@@ -447,7 +447,7 @@ function mapJoin(array, sep, func, self) {
  *   newline: string
  * }
  */
-module.exports = function SparqlGenerator(options = {}) {
+function _Generator(options = {}) {
   return {
     stringify: function (query) {
       var currentOptions = Object.create(options);
@@ -456,4 +456,7 @@ module.exports = function SparqlGenerator(options = {}) {
     },
     createGenerator: function() { return new Generator(options); }
   };
+};
+module.exports = {
+  Generator: _Generator,
 };

--- a/sparql.js
+++ b/sparql.js
@@ -3,41 +3,42 @@ var Generator = require('./lib/SparqlGenerator');
 var Wildcard = require("./lib/Wildcard").Wildcard;
 var { DataFactory } = require('rdf-data-factory');
 
+/**
+ * Creates a SPARQL parser with the given pre-defined prefixes and base IRI
+ * @param options {
+ *   prefixes?: { [prefix: string]: string },
+ *   baseIRI?: string,
+ *   factory?: import('rdf-js').DataFactory,
+ *   sparqlStar?: boolean,
+ *   skipValidation?: boolean,
+ *   skipUngroupedVariableCheck?: boolean
+ * }
+ */
+var _Parser = function ({ prefixes, baseIRI, factory, sparqlStar, skipValidation, skipUngroupedVariableCheck, pathOnly } = {}) {
+  // Create a copy of the prefixes
+  var prefixesCopy = {};
+  for (var prefix in prefixes || {})
+    prefixesCopy[prefix] = prefixes[prefix];
+
+  // Create a new parser with the given prefixes
+  // (Workaround for https://github.com/zaach/jison/issues/241)
+  var parser = new Parser();
+  parser.parse = function () {
+    Parser.base = baseIRI || '';
+    Parser.prefixes = Object.create(prefixesCopy);
+    Parser.factory = factory || new DataFactory();
+    Parser.sparqlStar = Boolean(sparqlStar);
+    Parser.pathOnly = Boolean(pathOnly);
+    // We keep skipUngroupedVariableCheck for compatibility reasons.
+    Parser.skipValidation = Boolean(skipValidation) || Boolean(skipUngroupedVariableCheck)
+    return Parser.prototype.parse.apply(parser, arguments);
+  };
+  parser._resetBlanks = Parser._resetBlanks;
+  return parser;
+}
+
 module.exports = {
-  /**
-   * Creates a SPARQL parser with the given pre-defined prefixes and base IRI
-   * @param options {
-   *   prefixes?: { [prefix: string]: string },
-   *   baseIRI?: string,
-   *   factory?: import('rdf-js').DataFactory,
-   *   sparqlStar?: boolean,
-   *   skipValidation?: boolean,
-   *   skipUngroupedVariableCheck?: boolean
-   * }
-   */
-  Parser: function ({ prefixes, baseIRI, factory, sparqlStar, skipValidation, skipUngroupedVariableCheck, pathOnly } = {}) {
-
-    // Create a copy of the prefixes
-    var prefixesCopy = {};
-    for (var prefix in prefixes || {})
-      prefixesCopy[prefix] = prefixes[prefix];
-
-    // Create a new parser with the given prefixes
-    // (Workaround for https://github.com/zaach/jison/issues/241)
-    var parser = new Parser();
-    parser.parse = function () {
-      Parser.base = baseIRI || '';
-      Parser.prefixes = Object.create(prefixesCopy);
-      Parser.factory = factory || new DataFactory();
-      Parser.sparqlStar = Boolean(sparqlStar);
-      Parser.pathOnly = Boolean(pathOnly);
-      // We keep skipUngroupedVariableCheck for compatibility reasons.
-      Parser.skipValidation = Boolean(skipValidation) || Boolean(skipUngroupedVariableCheck)
-      return Parser.prototype.parse.apply(parser, arguments);
-    };
-    parser._resetBlanks = Parser._resetBlanks;
-    return parser;
-  },
+  Parser: _Parser,
   Generator: Generator,
   Wildcard: Wildcard,
 };

--- a/sparql.js
+++ b/sparql.js
@@ -1,7 +1,7 @@
-var Parser = require('./lib/SparqlParser').Parser;
-var Generator = require('./lib/SparqlGenerator');
-var Wildcard = require("./lib/Wildcard").Wildcard;
-var { DataFactory } = require('rdf-data-factory');
+const { Parser } = require('./lib/SparqlParser');
+const { Generator } = require('./lib/SparqlGenerator');
+const { Wildcard } = require('./lib/Wildcard');
+const { DataFactory } = require('rdf-data-factory');
 
 /**
  * Creates a SPARQL parser with the given pre-defined prefixes and base IRI
@@ -14,15 +14,23 @@ var { DataFactory } = require('rdf-data-factory');
  *   skipUngroupedVariableCheck?: boolean
  * }
  */
-var _Parser = function ({ prefixes, baseIRI, factory, sparqlStar, skipValidation, skipUngroupedVariableCheck, pathOnly } = {}) {
+function _Parser({
+    prefixes,
+    baseIRI,
+    factory,
+    pathOnly,
+    sparqlStar,
+    skipValidation,
+    skipUngroupedVariableCheck,
+} = {}) {
   // Create a copy of the prefixes
-  var prefixesCopy = {};
-  for (var prefix in prefixes || {})
+  const prefixesCopy = {};
+  for (const prefix in prefixes ?? {})
     prefixesCopy[prefix] = prefixes[prefix];
 
   // Create a new parser with the given prefixes
   // (Workaround for https://github.com/zaach/jison/issues/241)
-  var parser = new Parser();
+  const parser = new Parser();
   parser.parse = function () {
     Parser.base = baseIRI || '';
     Parser.prefixes = Object.create(prefixesCopy);
@@ -39,6 +47,6 @@ var _Parser = function ({ prefixes, baseIRI, factory, sparqlStar, skipValidation
 
 module.exports = {
   Parser: _Parser,
-  Generator: Generator,
-  Wildcard: Wildcard,
+  Generator,
+  Wildcard,
 };


### PR DESCRIPTION
Node attempts to make CommonJS exports available as named exports when imported by ES modules. It does this by statically analyzing the CJS module using `cjs-module-lexer`. However, as the name implies, it's a lexer, not a full parser, and it only supports limited common patterns for building a `module.exports` object. Notably, it supports `module.exports = { ... }`, but only if the values in that object are all simple identifiers. Otherwise it will include only the keys up to the first non-identifier value it finds, and bail after that.

https://github.com/nodejs/cjs-module-lexer/issues/47

That means that the `Generator` and `Wildcard` exports were missing in ES modules. This change makes them available again.