### PR TITLE
Expand regex for absolute IRIs

### DIFF
--- a/lib/sparql.jison
+++ b/lib/sparql.jison
@@ -57,7 +57,7 @@
     if (iri[0] === '<')
       iri = iri.substring(1, iri.length - 1);
     // Return absolute IRIs unmodified
-    if (/^[a-z]+:/i.test(iri))
+    if (/^[a-z][a-z0-9.+-]*:/i.test(iri))
       return iri;
     if (!Parser.base)
       throw new Error('Cannot resolve relative IRI ' + iri + ' because no base IRI was set.');


### PR DESCRIPTION
Fixes #176.

I updated to the regex to match the grammar in https://www.ietf.org/rfc/rfc2396.txt:

>Scheme names consist of a sequence of characters beginning with a
   lower case letter and followed by any combination of lower case
   letters, digits, plus ("+"), period ("."), or hyphen ("-").  For
   resiliency, programs interpreting URI should treat upper case letters
   as equivalent to lower case in scheme names (e.g., allow "HTTP" as
   well as "http").
>
>      scheme        = alpha *( alpha | digit | "+" | "-" | "." )