### PR TITLE
Preserve LIMIT 0

### DIFF
--- a/lib/SparqlGenerator.js
+++ b/lib/SparqlGenerator.js
@@ -76,7 +76,8 @@ Generator.prototype.toQuery = function (q) {
 
   if (q.offset)
     query += 'OFFSET ' + q.offset + this._newline;
-  if (q.limit)
+  //do integer check to preserve LIMIT 0
+  if (Number.isInteger(q.limit))
     query += 'LIMIT ' + q.limit + this._newline;
 
   if (q.values)

--- a/test/SparqlGenerator-test.js
+++ b/test/SparqlGenerator-test.js
@@ -123,6 +123,17 @@ describe('A SPARQL generator', function () {
       'COPY SILENT DEFAULT TO <http://example.org/named>';
     expect(generatedQuery).toEqual(expectedQuery);
   });
+
+  it('should preserve limits with 0', function () {
+    var parser = new SparqlParser();
+    var parsedQuery = parser.parse('SELECT * WHERE { ?s ?p ?o. } LIMIT 0');
+    var generator = new SparqlGenerator();
+    var generatedQuery = generator.stringify(parsedQuery);
+    var expectedQuery =
+      'SELECT * WHERE { ?s ?p ?o. }\n' +
+      'LIMIT 0';
+    expect(generatedQuery).toEqual(expectedQuery);
+  });
 });
 
 function testQueries(directory, settings) {


### PR DESCRIPTION
LIMIT 0 should not be dropped / database should return 0 results. 

See https://www.w3.org/TR/sparql11-query/#modResultLimit

Fixes #183