### PR TITLE
Add Option to Keep Query Prefixes

### DIFF
--- a/lib/SparqlGenerator.js
+++ b/lib/SparqlGenerator.js
@@ -90,10 +90,12 @@ Generator.prototype.toQuery = function (q) {
 Generator.prototype.baseAndPrefixes = function (q) {
   var base = q.base ? ('BASE <' + q.base + '>' + this._newline) : '';
   var prefixes = '';
+  var queryPrefixes=Object.keys(q.prefixes || {});
   for (var key in q.prefixes) {
-    if (this._options.allPrefixes || this._usedPrefixes[key])
-      prefixes += 'PREFIX ' + key + ': <' + q.prefixes[key] + '>' + this._newline;
-  }
+    if (this._options.allPrefixes || this._usedPrefixes[key] ||
+      (this._options.keepQueryPrefixes && queryPrefixes.includes(key)))
+    prefixes += 'PREFIX ' + key + ': <' + q.prefixes[key] + '>' + this._newline;
+}
   return base + prefixes;
 };
 
@@ -451,6 +453,7 @@ function mapJoin(array, sep, func, self) {
 /**
  * @param options {
  *   allPrefixes: boolean,
+ *   keepQueryPrefixes: boolean, 
  *   indentation: string,
  *   newline: string
  * }

--- a/test/SparqlGenerator-test.js
+++ b/test/SparqlGenerator-test.js
@@ -13,6 +13,20 @@ var parsedQueriesPath = __dirname + '/../test/parsedQueries/';
 var unusedPrefixesPath = __dirname + '/../test/unusedPrefixes/';
 
 describe('A SPARQL generator', function () {
+  it('should preserve mentioned prefixes in the query', function () {
+    var parser = new SparqlParser({
+      prefixes: {
+        schema: "https://schema.org/",
+        owl: "http://www.w3.org/2002/07/owl#"
+      }
+    });
+    var parsedQuery = parser.parse('PREFIX db_opt: <https://db.control.param_10> \n SELECT * WHERE {?s a owl:Class}');
+    var generator = new SparqlGenerator({allPrefixes: false, keepQueryPrefixes: true});
+    var generatedQuery = generator.stringify(parsedQuery);
+    var expectedQuery ='PREFIX db_opt: <https://db.control.param_10>\nPREFIX owl: <http://www.w3.org/2002/07/owl#>\nSELECT * WHERE { ?s <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> owl:Class. }';
+    expect(generatedQuery).toEqual(expectedQuery);
+  });
+
   var defaultGenerator = new SparqlGenerator();
 
   describe('in SPARQL mode', () => {


### PR DESCRIPTION
This PR extends the options paramaters of the SparqlGenerator.

The newly introduced option parameter `keepQueryPrefixes` allows to combine the used prefixes of the query body and the once mentioned in the Prefix defintions.

 

The use-case is the following: 

Some database vendors can provide hints to the database using Prefixes, however the current available options (used Prefixes or all Prefixes) either ignore the optimization prefixes or add all available prefixes which results in a very large prefix definitions and more challenging debuging of queries. 


Related Issue: https://github.com/RubenVerborgh/SPARQL.js/issues/186
